### PR TITLE
Fix macros for reserved prefixes on lifetimes

### DIFF
--- a/nject-macro/src/inject.rs
+++ b/nject-macro/src/inject.rs
@@ -55,7 +55,7 @@ pub(crate) fn handle_inject(item: TokenStream, attr: TokenStream) -> syn::Result
         impl<'prov, #(#generic_params,)*NjectProvider> nject::Injectable<'prov, #ident<#(#generic_keys),*>, NjectProvider> for #ident<#(#generic_keys),*>
             where
                 #prov_lifetimes
-                NjectProvider: #(nject::Provider<'prov, #prov_types>)+*,#where_predicates
+                NjectProvider: #(nject::Provider<'prov, #prov_types>)+*, #where_predicates
         {
             #[inline]
             fn inject(provider: &'prov NjectProvider) -> #ident<#(#generic_keys),*> {

--- a/nject-macro/src/injectable.rs
+++ b/nject-macro/src/injectable.rs
@@ -122,7 +122,7 @@ pub(crate) fn handle_injectable(item: TokenStream) -> syn::Result<TokenStream> {
         impl<'prov, #(#generic_params,)*NjectProvider> nject::Injectable<'prov, #ident<#(#generic_keys),*>, NjectProvider> for #ident<#(#generic_keys),*>
             where
                 #prov_lifetimes
-                NjectProvider: #(nject::Provider<'prov, #prov_types>)+*,#where_predicates
+                NjectProvider: #(nject::Provider<'prov, #prov_types>)+*, #where_predicates
         {
             #[inline]
             fn inject(provider: &'prov NjectProvider) -> #ident<#(#generic_keys),*> {

--- a/nject-macro/src/module/mod.rs
+++ b/nject-macro/src/module/mod.rs
@@ -113,7 +113,7 @@ pub(crate) fn handle_module(attr: TokenStream, item: TokenStream) -> syn::Result
                 impl<'prov, #(#generic_params,)*NjectProvider> nject::RefInjectable<'prov, #ty, NjectProvider> for #ident<#(#generic_keys),*>
                     where
                         #prov_lifetimes
-                        NjectProvider: #(nject::Provider<'prov, #prov_types>)+*,#where_predicates
+                        NjectProvider: #(nject::Provider<'prov, #prov_types>)+*, #where_predicates
                 {
                     #[inline]
                     fn inject(&'prov self, provider: &'prov NjectProvider) -> #ty {
@@ -181,7 +181,7 @@ pub(crate) fn handle_module(attr: TokenStream, item: TokenStream) -> syn::Result
                 impl<'prov, #(#generic_params,)*NjectProvider> nject::Injectable<'prov, #ty, NjectProvider> for #ty
                     where
                         #prov_lifetimes
-                        NjectProvider: nject::Import<#ident<#(#generic_keys),*>>,#where_predicates
+                        NjectProvider: nject::Import<#ident<#(#generic_keys),*>>, #where_predicates
                 {
                     #[inline]
                     fn inject(provider: &'prov NjectProvider) -> #ty {

--- a/nject-macro/src/provider.rs
+++ b/nject-macro/src/provider.rs
@@ -125,7 +125,7 @@ pub(crate) fn handle_provider(
         #input
 
         impl<'prov, #(#generic_params,)*Njecty> nject::Provider<'prov, Njecty> for #ident<#(#generic_keys),*>
-            where Njecty: nject::Injectable<'prov, Njecty, #ident<#(#generic_keys),*>>,#where_predicates
+            where Njecty: nject::Injectable<'prov, Njecty, #ident<#(#generic_keys),*>>, #where_predicates
         {
             #[inline]
             fn provide(&'prov self) -> Njecty {
@@ -194,7 +194,7 @@ fn gen_imports_for_import_attr(
         let imported_type_output = exported_types.iter().map(|ty| {
             quote!{
 
-                impl<'prov#(,#generic_params)*> nject::Provider<'prov, #ty> for #ident<#(#generic_keys),*>
+                impl<'prov, #(#generic_params),*> nject::Provider<'prov, #ty> for #ident<#(#generic_keys),*>
                     where #where_predicates
                 {
                     #[inline]
@@ -285,7 +285,7 @@ fn gen_providers_for_provide_attr_on_fields(
 
             quote! {
 
-                impl<'prov#(,#generic_params)*> nject::Provider<'prov, #ty> for #ident<#(#generic_keys),*>
+                impl<'prov, #(#generic_params),*> nject::Provider<'prov, #ty> for #ident<#(#generic_keys),*>
                     where #where_predicates
                 {
                     #[inline]
@@ -436,7 +436,7 @@ fn gen_scope_output(
                 where #where_predicates
             {
                 #[inline]
-                pub fn #scope_fn_ident<'scope>(&'scope self #(,#scope_args)*) -> #scope_ident<#(#scope_generic_keys),*>
+                pub fn #scope_fn_ident<'scope>(&'scope self, #(#scope_args),*) -> #scope_ident<#(#scope_generic_keys),*>
                 {
                     #scope_ident(#(#scope_field_provides,)* self)
                 }


### PR DESCRIPTION
Rust RFC 3101 reserved, in Rust 2021, prefixed identifiers such as `prefix#ident`.  This should have been applied to lifetimes before the release of the edition, but was not.  The Rust Project is planning to fix this, and this commit prepares this crate for that.

The key change is as follows.  There are many places where this crate says, in the context of `quote!(..)`:

```rust
impl<'prov, #(#generic_params),*>
```

But there were two places where this was spelled:

```rust
impl<'prov#(,#generic_params)*>
```

It's these that will break, and so this commit changes these to be consistent with the first spelling.  An alternate way to fix this would be to just add a space, such as:

```rust
impl<'prov #(,#generic_params)*>
```

...but the first fix seems more idiomatic.

The other changes here aren't strictly necessary, but they make things more consistent and rely on fewer peculiarities of the Rust parser.

After merging this, you'll probably want to make a new release of this crate for the benefit of any dependent crates.

This crate was identified via a crater run on this PR:

- https://github.com/rust-lang/rust/pull/126452