### PR TITLE
fix(router): update route path syntax to Axum 0.8 format

### DIFF
--- a/examples/axum/Cargo.toml
+++ b/examples/axum/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2024"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-axum = "0.8"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-tokio = { version = "1", features = ["full"] }
+axum = "0.8.4"
+serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.140"
+tokio = { version = "1.45.0", features = ["full"] }
 nject = { path = "../../nject" }

--- a/examples/axum/src/main.rs
+++ b/examples/axum/src/main.rs
@@ -22,7 +22,7 @@ async fn main() {
     let provider: &'static Provider = Box::leak(Box::new(InitProvider.provide()));
     let app = Router::new()
         .route("/api/users", post(create_user))
-        .route("/api/users/:id", get(get_user))
+        .route("/api/users/{id}", get(get_user))
         .with_state(provider);
 
     let addr = "0.0.0.0:3000";


### PR DESCRIPTION
Description:

This PR addresses the breaking changes introduced in Axum 0.8 by updating the route path syntax in the Axum example within the nject repository.

🛠 Changes Made:
1. Replaced deprecated colon-prefixed path parameters (e.g., :id) with the new curly-brace syntax (e.g., {id}) as per Axum 0.8.X requirements. This change resolves the runtime panic described in #63 

Reference: [Axum 0.8.0 Release Notes](https://tokio.rs/blog/2025-01-01-announcing-axum-0-8-0) ￼

2. Dependency Updates
	•	Upgraded all dependencies in the example to their latest versions to ensure compatibility and leverage recent improvements.
	•	Verified that the code compiles and runs successfully with the updated dependencies.