### PR TITLE
Allow usage in external crates; basic hygiene

### DIFF
--- a/examples/leptos/src/counter/store.rs
+++ b/examples/leptos/src/counter/store.rs
@@ -1,26 +1,26 @@
+use crate::Provider;
 use leptos::prelude::*;
 use nject::inject;
-use crate::Provider;
 
 #[inject({ 
 	let (read, write) = signal(0);
 	Self { read, write }
 })]
 pub struct CounterStore {
-	read: ReadSignal<i32>,
-	write: WriteSignal<i32>
+    read: ReadSignal<i32>,
+    write: WriteSignal<i32>,
 }
 
 impl CounterStore {
-	pub fn map<T>(&self, map: impl FnOnce(&i32) -> T) -> T {
-		self.read.with(map)
-	}
+    pub fn map<T>(&self, map: impl FnOnce(&i32) -> T) -> T {
+        self.read.with(map)
+    }
 
-	pub fn update(&self, update: impl FnOnce(&mut i32) ) {
-		self.write.update(update);
-	}
+    pub fn update(&self, update: impl FnOnce(&mut i32)) {
+        self.write.update(update);
+    }
 }
 
 pub fn counter_store<'a>() -> &'a CounterStore {
-	Provider::inject::<&CounterStore>()
+    Provider::inject::<&CounterStore>()
 }

--- a/nject-macro/src/core/mod.rs
+++ b/nject-macro/src/core/mod.rs
@@ -6,14 +6,24 @@ use proc_macro2::TokenStream;
 use quote::{ToTokens, quote};
 use std::path::PathBuf;
 use std::{ops::Deref, str::FromStr};
-use syn::Token;
 use syn::{
     AngleBracketedGenericArguments, Expr, ExprClosure, Fields, GenericArgument, GenericParam,
     Ident, Pat, PatType, Path, PathSegment, Type,
     parse::{Parse, ParseStream},
     spanned::Spanned,
 };
-
+use syn::{Token, parse_quote};
+pub struct PathWrapper(pub Path);
+impl Parse for PathWrapper {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        Ok(Self(if input.peek(Token![crate]) {
+            let _: Token![crate] = input.parse()?;
+            input.parse()?
+        } else {
+            parse_quote!(::nject)
+        }))
+    }
+}
 pub struct DeriveInput(syn::DeriveInput);
 
 impl Deref for DeriveInput {

--- a/nject-macro/src/injectable.rs
+++ b/nject-macro/src/injectable.rs
@@ -1,9 +1,10 @@
-use crate::core::{DeriveInput, FactoryExpr, error};
+use crate::core::{DeriveInput, FactoryExpr, PathWrapper, error};
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{
-    Expr, PatType, Token,
+    Expr, PatType, Path, Token,
     parse::{Parse, ParseStream},
+    parse_quote,
     spanned::Spanned,
 };
 
@@ -19,8 +20,9 @@ impl Parse for InjectExpr {
     }
 }
 
-pub(crate) fn handle_injectable(item: TokenStream) -> syn::Result<TokenStream> {
+pub(crate) fn handle_injectable(item: TokenStream, attr: TokenStream) -> syn::Result<TokenStream> {
     let input = syn::parse::<DeriveInput>(item)?;
+    let path = syn::parse::<PathWrapper>(attr)?.0;
     let ident = &input.ident;
     let fields = input.fields();
     let types = input.field_types();
@@ -65,7 +67,7 @@ pub(crate) fn handle_injectable(item: TokenStream) -> syn::Result<TokenStream> {
                     let inputs = attr
                         .1
                         .iter()
-                        .map(|x| quote! { let #x = provider.provide(); })
+                        .map(|x| quote! { let #x = #path::Provider::provide(provider); })
                         .collect::<Vec<_>>();
                     let output = &attr.0;
                     if inputs.is_empty() {
@@ -79,7 +81,7 @@ pub(crate) fn handle_injectable(item: TokenStream) -> syn::Result<TokenStream> {
                         }
                     }
                 }
-                None => quote! { provider.provide() },
+                None => quote! { #path::Provider::provide(provider) },
             });
             quote! { #ident(#(#items),*) }
         }
@@ -89,7 +91,7 @@ pub(crate) fn handle_injectable(item: TokenStream) -> syn::Result<TokenStream> {
                     let inputs = attr
                         .1
                         .iter()
-                        .map(|x| quote! { let #x = provider.provide(); })
+                        .map(|x| quote! { let #x = #path::Provider::provide(provider); })
                         .collect::<Vec<_>>();
                     let output = &attr.0;
                     quote! {
@@ -99,7 +101,7 @@ pub(crate) fn handle_injectable(item: TokenStream) -> syn::Result<TokenStream> {
                         }
                     }
                 }
-                None => quote! { #k: provider.provide() },
+                None => quote! { #k: #path::Provider::provide(provider) },
             });
             quote! { #ident { #(#items),* } }
         }
@@ -116,13 +118,13 @@ pub(crate) fn handle_injectable(item: TokenStream) -> syn::Result<TokenStream> {
     }
     prov_types.dedup_by(|a, b| a.to_string() == b.to_string());
     let output = quote! {
-        #[derive(nject::InjectableHelperAttr)]
+        #[derive(#path::InjectableHelperAttr)]
         #input
 
-        impl<'prov, #(#generic_params,)*NjectProvider> nject::Injectable<'prov, #ident<#(#generic_keys),*>, NjectProvider> for #ident<#(#generic_keys),*>
+        impl<'prov, #(#generic_params,)*NjectProvider> #path::Injectable<'prov, #ident<#(#generic_keys),*>, NjectProvider> for #ident<#(#generic_keys),*>
             where
                 #prov_lifetimes
-                NjectProvider: #(nject::Provider<'prov, #prov_types>)+*, #where_predicates
+                NjectProvider: #(#path::Provider<'prov, #prov_types>)+*, #where_predicates
         {
             #[inline]
             fn inject(provider: &'prov NjectProvider) -> #ident<#(#generic_keys),*> {

--- a/nject-macro/src/lib.rs
+++ b/nject-macro/src/lib.rs
@@ -48,8 +48,8 @@ pub fn scope_helper_attr(_item: TokenStream) -> TokenStream {
 /// let facade: Facade = Provider.provide();
 /// ```
 #[proc_macro_attribute]
-pub fn injectable(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    handle_injectable(item).unwrap_or_else(|e| e.to_compile_error().into())
+pub fn injectable(attr: TokenStream, item: TokenStream) -> TokenStream {
+    handle_injectable(item, attr).unwrap_or_else(|e| e.to_compile_error().into())
 }
 
 /// Use the given value to inject.
@@ -104,8 +104,8 @@ pub fn inject(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// let facade: Facade = provider.provide();
 /// ```
 #[proc_macro_attribute]
-pub fn provider(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    handle_provider(item).unwrap_or_else(|e| e.to_compile_error().into())
+pub fn provider(attr: TokenStream, item: TokenStream) -> TokenStream {
+    handle_provider(item, attr).unwrap_or_else(|e| e.to_compile_error().into())
 }
 
 /// Declare a module to export internal types.

--- a/nject-macro/src/provider.rs
+++ b/nject-macro/src/provider.rs
@@ -138,7 +138,7 @@ pub(crate) fn handle_provider(
         {
             #[inline]
             fn provide(&'prov self) -> Njecty {
-                Njecty::inject(self)
+                <Njecty as #path::Injectable<'prov, Njecty, #ident<#(#generic_keys),*>>>::inject(self)
             }
         }
 
@@ -166,7 +166,7 @@ pub(crate) fn handle_provider(
         where #where_predicates
         {
             #[inline]
-            pub fn iter<'prov, Value>(&'prov self) -> impl Iterator<Item = Value> + use<'prov #(,#generic_keys)*, Value>
+            pub fn iter<'prov, Value>(&'prov self) -> impl #path::core::iter::Iterator<Item = Value> + use<'prov #(,#generic_keys)*, Value>
             where Self: #path::Iterable<'prov, Value>
             {
                 #path::Iterable::<'prov, Value>::iter(self)
@@ -237,23 +237,23 @@ fn gen_imports_for_import_attr(
                 where #where_predicates
             {
                 #[inline]
-                fn iter(&'prov self) -> impl Iterator<Item = #ty> {
+                fn iter(&'prov self) -> impl #path::core::iter::Iterator<Item = #ty> {
                     struct NjectIterator<'prov, #(#generic_params),*> {
                         provider: &'prov #ident<#(#generic_keys),*>,
                         index: usize,
                     }
-                    impl<'prov, #(#generic_params),*> Iterator for NjectIterator<'prov, #(#generic_keys),*> {
+                    impl<'prov, #(#generic_params),*> #path::core::iter::Iterator for NjectIterator<'prov, #(#generic_keys),*> {
                         type Item = #ty;
 
-                        fn next(&mut self) -> Option<Self::Item> {
+                        fn next(&mut self) -> #path::core::option::Option<Self::Item> {
                             let result = match self.index {
                                 #( #iter_match_outputs )*
                                 _ => {
-                                    return None;
+                                    return #path::core::option::Option::None;
                                 }
                             };
                             self.index += 1;
-                            Some(result)
+                            #path::core::option::Option::Some(result)
                         }
                     }
                     NjectIterator {

--- a/nject-macro/src/provider.rs
+++ b/nject-macro/src/provider.rs
@@ -1,8 +1,10 @@
-use crate::core::{DeriveInput, FactoryExpr, FieldFactoryExpr, collection::group_by, error};
+use crate::core::{
+    DeriveInput, FactoryExpr, FieldFactoryExpr, PathWrapper, collection::group_by, error,
+};
 use proc_macro2::Span;
 use quote::{format_ident, quote};
 use syn::{
-    Expr, Field, GenericParam, Ident, Lifetime, LifetimeParam, PatType, Token, Type,
+    Expr, Field, GenericParam, Ident, Lifetime, LifetimeParam, PatType, Path, Token, Type,
     parse::{Parse, ParseStream},
     punctuated::Punctuated,
     spanned::Spanned,
@@ -29,8 +31,10 @@ type ProvideFieldInput = FieldFactoryExpr;
 
 pub(crate) fn handle_provider(
     item: proc_macro::TokenStream,
+    attr: proc_macro::TokenStream,
 ) -> syn::Result<proc_macro::TokenStream> {
     let input = syn::parse::<DeriveInput>(item)?;
+    let path = syn::parse::<PathWrapper>(attr)?.0;
     let ident = &input.ident;
     let fields = input.fields().iter().collect::<Vec<_>>();
     let generic_keys = input.generic_keys();
@@ -89,6 +93,7 @@ pub(crate) fn handle_provider(
         &fields_path_prefix,
         &fields,
         &import_attr_indexes,
+        &path,
     );
     let provide_outputs = gen_providers_for_provide_attr_on_fields(
         ident,
@@ -98,6 +103,7 @@ pub(crate) fn handle_provider(
         &fields_path_prefix,
         &fields,
         &provide_attr_indexes,
+        &path,
     );
     let input_provide_outputs = gen_providers_for_provide_attr_on_struct(
         ident,
@@ -105,26 +111,30 @@ pub(crate) fn handle_provider(
         &generic_keys,
         &where_predicates,
         &provide_input_attr,
+        &path,
     );
-    let scope_output = gen_scope_output(GenScopeOuptutInput {
-        visibility: &input.vis,
-        ident,
-        generic_params: &generic_params,
-        generic_keys: &generic_keys,
-        where_predicates: &where_predicates,
-        fields: &fields,
-        import_attr_indexes: &import_attr_indexes,
-        provide_attr_indexes: &provide_attr_indexes,
-        provide_input_attr: &provide_input_attr,
-        scope_input_attr: &scope_attr,
-    })?;
+    let scope_output = gen_scope_output(
+        GenScopeOuptutInput {
+            visibility: &input.vis,
+            ident,
+            generic_params: &generic_params,
+            generic_keys: &generic_keys,
+            where_predicates: &where_predicates,
+            fields: &fields,
+            import_attr_indexes: &import_attr_indexes,
+            provide_attr_indexes: &provide_attr_indexes,
+            provide_input_attr: &provide_input_attr,
+            scope_input_attr: &scope_attr,
+        },
+        &path,
+    )?;
 
     let output = quote! {
-        #[derive(nject::ProviderHelperAttr)]
+        #[derive(#path::ProviderHelperAttr)]
         #input
 
-        impl<'prov, #(#generic_params,)*Njecty> nject::Provider<'prov, Njecty> for #ident<#(#generic_keys),*>
-        where Njecty: nject::Injectable<'prov, Njecty, #ident<#(#generic_keys),*>>, #where_predicates
+        impl<'prov, #(#generic_params,)*Njecty> #path::Provider<'prov, Njecty> for #ident<#(#generic_keys),*>
+        where Njecty: #path::Injectable<'prov, Njecty, #ident<#(#generic_keys),*>>, #where_predicates
         {
             #[inline]
             fn provide(&'prov self) -> Njecty {
@@ -132,11 +142,11 @@ pub(crate) fn handle_provider(
             }
         }
 
-        impl<'prov, #(#generic_params,)*Njecty> nject::Provider<'prov, &'prov dyn nject::Provider<'prov, Njecty>> for #ident<#(#generic_keys),*>
-        where Self: nject::Provider<'prov, Njecty>, #where_predicates
+        impl<'prov, #(#generic_params,)*Njecty> #path::Provider<'prov, &'prov dyn #path::Provider<'prov, Njecty>> for #ident<#(#generic_keys),*>
+        where Self: #path::Provider<'prov, Njecty>, #where_predicates
         {
             #[inline]
-            fn provide(&'prov self) -> &'prov dyn nject::Provider<'prov, Njecty> {
+            fn provide(&'prov self) -> &'prov dyn #path::Provider<'prov, Njecty> {
                 self
             }
         }
@@ -146,9 +156,9 @@ pub(crate) fn handle_provider(
         {
             #[inline]
             pub fn provide<'prov, Njecty>(&'prov self) -> Njecty
-            where Self: nject::Provider<'prov, Njecty>
+            where Self: #path::Provider<'prov, Njecty>
             {
-                <Self as nject::Provider<'prov, Njecty>>::provide(self)
+                <Self as #path::Provider<'prov, Njecty>>::provide(self)
             }
         }
 
@@ -157,9 +167,9 @@ pub(crate) fn handle_provider(
         {
             #[inline]
             pub fn iter<'prov, Value>(&'prov self) -> impl Iterator<Item = Value> + use<'prov #(,#generic_keys)*, Value>
-            where Self: nject::Iterable<'prov, Value>
+            where Self: #path::Iterable<'prov, Value>
             {
-                nject::Iterable::<'prov, Value>::iter(self)
+                #path::Iterable::<'prov, Value>::iter(self)
             }
         }
         #(#import_outputs)*
@@ -179,6 +189,7 @@ fn gen_imports_for_import_attr(
     fields_path_prefix: &proc_macro2::TokenStream,
     fields: &[&syn::Field],
     import_attr_indexes: &[usize],
+    path: &Path,
 ) -> Vec<proc_macro2::TokenStream> {
     let imported_modules = import_attr_indexes
         .iter()
@@ -217,12 +228,12 @@ fn gen_imports_for_import_attr(
         });
         let iter_match_outputs = types_by_module.iter().flat_map(|(_, types_for_module)| {
             types_for_module.iter().enumerate().map(|(mod_index, (index, (_, ty, field_key)))| {
-                quote! { #index => nject::RefIterable::<#ty, #ident<#(#generic_keys),*>>::inject(&self.provider.#fields_path_prefix #field_key, self.provider, #mod_index), }
+                quote! { #index => #path::RefIterable::<#ty, #ident<#(#generic_keys),*>>::inject(&self.provider.#fields_path_prefix #field_key, self.provider, #mod_index), }
             })
         });
         quote!{
 
-            impl<'prov, #(#generic_params),*> nject::Iterable<'prov, #ty> for #ident<#(#generic_keys),*>
+            impl<'prov, #(#generic_params),*> #path::Iterable<'prov, #ty> for #ident<#(#generic_keys),*>
                 where #where_predicates
             {
                 #[inline]
@@ -257,12 +268,12 @@ fn gen_imports_for_import_attr(
         let (_, ty, field_key) = types.last().unwrap();
         quote!{
 
-            impl<'prov, #(#generic_params),*> nject::Provider<'prov, #ty> for #ident<#(#generic_keys),*>
+            impl<'prov, #(#generic_params),*> #path::Provider<'prov, #ty> for #ident<#(#generic_keys),*>
                 where #where_predicates
             {
                 #[inline]
                 fn provide(&'prov self) -> #ty {
-                    nject::RefInjectable::<#ty, Self>::inject(&self.#fields_path_prefix #field_key, self)
+                    #path::RefInjectable::<#ty, Self>::inject(&self.#fields_path_prefix #field_key, self)
                 }
             }
         }
@@ -278,7 +289,7 @@ fn gen_imports_for_import_attr(
         };
         quote! {
 
-            impl<#(#generic_params),*> nject::Import<#ty_output> for #ident<#(#generic_keys),*>
+            impl<#(#generic_params),*> #path::Import<#ty_output> for #ident<#(#generic_keys),*>
                 where #where_predicates
             {
                 #[inline]
@@ -302,6 +313,7 @@ fn gen_providers_for_provide_attr_on_fields(
     fields_path_prefix: &proc_macro2::TokenStream,
     fields: &[&syn::Field],
     provide_attr_indexes: &[(usize, Vec<&syn::Attribute>)],
+    path: &Path,
 ) -> Vec<proc_macro2::TokenStream> {
     let provide_outputs = provide_attr_indexes.iter().map(|(i, attrs)| {
         let field = fields[*i];
@@ -357,7 +369,7 @@ fn gen_providers_for_provide_attr_on_fields(
 
             quote! {
 
-                impl<'prov, #(#generic_params),*> nject::Provider<'prov, #ty> for #ident<#(#generic_keys),*>
+                impl<'prov, #(#generic_params),*> #path::Provider<'prov, #ty> for #ident<#(#generic_keys),*>
                     where #where_predicates
                 {
                     #[inline]
@@ -381,6 +393,7 @@ pub(crate) fn gen_providers_for_provide_attr_on_struct(
     generic_keys: &[proc_macro2::TokenStream],
     where_predicates: &proc_macro2::TokenStream,
     provide_input_attr: &[&syn::Attribute],
+    path: &Path,
 ) -> Vec<proc_macro2::TokenStream> {
     let input_provide_outputs = provide_input_attr
         .iter()
@@ -392,7 +405,7 @@ pub(crate) fn gen_providers_for_provide_attr_on_struct(
             };
             quote!{
 
-                impl<'prov, #(#generic_params),*> nject::Provider<'prov, #ty> for #ident<#(#generic_keys),*>
+                impl<'prov, #(#generic_params),*> #path::Provider<'prov, #ty> for #ident<#(#generic_keys),*>
                     where #where_predicates
                 {
                     #[inline]
@@ -432,6 +445,7 @@ fn gen_scope_output(
         provide_input_attr,
         scope_input_attr,
     }: GenScopeOuptutInput<'_>,
+    path: &Path,
 ) -> syn::Result<proc_macro2::TokenStream> {
     if scope_input_attr.is_empty() {
         return Ok(proc_macro2::TokenStream::new());
@@ -479,9 +493,9 @@ fn gen_scope_output(
         });
         let root_path = syn::Index::from(scope_fields.len());
         let fields_path_prefix = quote!{#root_path.};
-        let import_outputs = gen_imports_for_import_attr(&scope_ident, &scope_generic_params, &scope_generic_keys, where_predicates, &fields_path_prefix, fields, import_attr_indexes);
-        let provide_outputs = gen_providers_for_provide_attr_on_fields(&scope_ident, &scope_generic_params, &scope_generic_keys, where_predicates, &fields_path_prefix, fields, provide_attr_indexes);
-        let input_provide_outputs = gen_providers_for_provide_attr_on_struct(&scope_ident, &scope_generic_params, &scope_generic_keys, where_predicates, provide_input_attr);
+        let import_outputs = gen_imports_for_import_attr(&scope_ident, &scope_generic_params, &scope_generic_keys, where_predicates, &fields_path_prefix, fields, import_attr_indexes,path);
+        let provide_outputs = gen_providers_for_provide_attr_on_fields(&scope_ident, &scope_generic_params, &scope_generic_keys, where_predicates, &fields_path_prefix, fields, provide_attr_indexes,path);
+        let input_provide_outputs = gen_providers_for_provide_attr_on_struct(&scope_ident, &scope_generic_params, &scope_generic_keys, where_predicates, provide_input_attr,path);
         let scope_field_provides = scope_fields.iter()
             .enumerate()
             .map(|(i, _)| match arg_scope_fields[i] {
@@ -516,7 +530,7 @@ fn gen_scope_output(
 
             #[provider]
             #[injectable]
-            #[derive(nject::ScopeHelperAttr)]
+            #[derive(#path::ScopeHelperAttr)]
             #visibility struct #scope_ident<'scope, #(#generic_params),*>(#(#scope_field_outputs,)* &'scope #ident<#(#generic_keys),*>)
                 where #where_predicates;
 

--- a/nject/src/lib.rs
+++ b/nject/src/lib.rs
@@ -1,7 +1,8 @@
 #![no_std]
 #![allow(clippy::needless_doctest_main)]
 #![doc = include_str!("../README.md")]
-
+#[doc(hidden)]
+pub use core;
 #[cfg(feature = "macro")]
 pub use nject_macro::{
     InjectableHelperAttr, ModuleHelperAttr, ProviderHelperAttr, ScopeHelperAttr, inject,


### PR DESCRIPTION
I want to depend on this crate in my frameworks, so having the ability to reexport it and use the reexport would be critical.