### PR TITLE
Add named injection

### DIFF
--- a/nject-macro/src/injectable.rs
+++ b/nject-macro/src/injectable.rs
@@ -2,19 +2,48 @@ use crate::core::{DeriveInput, FactoryExpr, error};
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{
-    Expr, PatType, Token,
+    Expr, PatType, Token, Type,
     parse::{Parse, ParseStream},
     spanned::Spanned,
 };
 
-struct InjectExpr(Box<Expr>, Vec<PatType>);
+enum InjectExpr {
+    /// A direct expression, optionally with factory inputs: `expr` or `|dep: T| expr`
+    Value(Box<Expr>, Vec<PatType>),
+    /// A named injection tag type: `named(TagType)`
+    Named(Type),
+    /// A named injection string key: `named("key")` — resolved via `Key<{hash}>`
+    NamedStr(u128),
+}
 impl Parse for InjectExpr {
     fn parse(input: ParseStream) -> syn::Result<Self> {
+        // Check for `named(TagType)` or `named("string_key")` syntax
+        if input.peek(syn::Ident) {
+            let fork = input.fork();
+            if let Ok(ident) = fork.parse::<syn::Ident>() {
+                if ident == "named" {
+                    // Commit to the `named(...)` parse
+                    input.parse::<syn::Ident>()?; // consume "named"
+                    let content;
+                    syn::parenthesized!(content in input);
+                    // Check for string literal: named("key")
+                    if content.peek(syn::LitStr) {
+                        let lit: syn::LitStr = content.parse()?;
+                        let hash_bytes = crate::core::hash::fnv(lit.value().as_bytes());
+                        let hash = u128::from_be_bytes(hash_bytes);
+                        return Ok(InjectExpr::NamedStr(hash));
+                    }
+                    // Otherwise parse as type: named(TagType)
+                    let tag_type: Type = content.parse()?;
+                    return Ok(InjectExpr::Named(tag_type));
+                }
+            }
+        }
         if input.peek(Token![|]) {
             let expr = FactoryExpr::parse(input)?;
-            Ok(InjectExpr(expr.body, expr.inputs))
+            Ok(InjectExpr::Value(expr.body, expr.inputs))
         } else {
-            Ok(InjectExpr(input.parse()?, vec![]))
+            Ok(InjectExpr::Value(input.parse()?, vec![]))
         }
     }
 }
@@ -55,20 +84,24 @@ pub(crate) fn handle_injectable(item: TokenStream) -> syn::Result<TokenStream> {
     };
     let creation_output = match keys.is_empty() && !types.is_empty() {
         true => {
-            let items = types.iter().zip(&attributes).map(|(_, a)| match a {
-                Some(attr) => {
-                    let inputs = attr
-                        .1
+            let items = types.iter().zip(&attributes).map(|(ty, a)| match a {
+                Some(InjectExpr::Named(tag)) => {
+                    quote! { nject::Named::<#tag, #ty>::into_inner(provider.provide()) }
+                }
+                Some(InjectExpr::NamedStr(hash)) => {
+                    quote! { nject::Named::<nject::Key<#hash>, #ty>::into_inner(provider.provide()) }
+                }
+                Some(InjectExpr::Value(output, inputs)) => {
+                    let input_stmts = inputs
                         .iter()
                         .map(|x| quote! { let #x = provider.provide(); })
                         .collect::<Vec<_>>();
-                    let output = &attr.0;
-                    if inputs.is_empty() {
+                    if input_stmts.is_empty() {
                         quote! { #output }
                     } else {
                         quote! {
                             {
-                                #(#inputs)*
+                                #(#input_stmts)*
                                 #output
                             }
                         }
@@ -79,17 +112,25 @@ pub(crate) fn handle_injectable(item: TokenStream) -> syn::Result<TokenStream> {
             quote! { #ident(#(#items),*) }
         }
         false => {
-            let items = keys.iter().zip(&attributes).map(|(k, a)| match a {
-                Some(attr) => {
-                    let inputs = attr
-                        .1
+            let items = keys.iter().zip(types.iter()).zip(&attributes).map(|((k, ty), a)| match a {
+                Some(InjectExpr::Named(tag)) => {
+                    quote! {
+                        #k: nject::Named::<#tag, #ty>::into_inner(provider.provide())
+                    }
+                }
+                Some(InjectExpr::NamedStr(hash)) => {
+                    quote! {
+                        #k: nject::Named::<nject::Key<#hash>, #ty>::into_inner(provider.provide())
+                    }
+                }
+                Some(InjectExpr::Value(output, inputs)) => {
+                    let input_stmts = inputs
                         .iter()
                         .map(|x| quote! { let #x = provider.provide(); })
                         .collect::<Vec<_>>();
-                    let output = &attr.0;
                     quote! {
                         #k: {
-                            #(#inputs)*
+                            #(#input_stmts)*
                             #output
                         }
                     }
@@ -101,12 +142,21 @@ pub(crate) fn handle_injectable(item: TokenStream) -> syn::Result<TokenStream> {
     };
     let mut prov_types = Vec::<_>::with_capacity(types.len());
     for (t, a) in types.iter().zip(&attributes) {
-        if let Some(attr) = a {
-            for attr_type in attr.1.iter().map(|x| &x.ty) {
-                prov_types.push(quote! {#attr_type});
+        match a {
+            Some(InjectExpr::Named(tag)) => {
+                prov_types.push(quote! { nject::Named<#tag, #t> });
             }
-        } else {
-            prov_types.push(quote! {#t});
+            Some(InjectExpr::NamedStr(hash)) => {
+                prov_types.push(quote! { nject::Named<nject::Key<#hash>, #t> });
+            }
+            Some(InjectExpr::Value(_, inputs)) => {
+                for attr_type in inputs.iter().map(|x| &x.ty) {
+                    prov_types.push(quote! {#attr_type});
+                }
+            }
+            None => {
+                prov_types.push(quote! {#t});
+            }
         }
     }
     prov_types.dedup_by(|a, b| a.to_string() == b.to_string());

--- a/nject-macro/src/lib.rs
+++ b/nject-macro/src/lib.rs
@@ -108,6 +108,23 @@ pub fn provider(_attr: TokenStream, item: TokenStream) -> TokenStream {
     handle_provider(item).unwrap_or_else(|e| e.to_compile_error().into())
 }
 
+/// Produce a [`Key`] type from a string literal, for use in type position.
+///
+/// ```rust
+/// use nject::{Named, key};
+///
+/// type DbUrl = Named<key!("db_url"), String>;
+/// let url: DbUrl = Named::new("postgres://localhost".into());
+/// assert_eq!(*url, "postgres://localhost");
+/// ```
+#[proc_macro]
+pub fn key(input: TokenStream) -> TokenStream {
+    let lit: syn::LitStr = syn::parse(input).expect("key! expects a string literal");
+    let hash = core::hash::fnv(lit.value().as_bytes());
+    let hash = u128::from_be_bytes(hash);
+    quote::quote! { nject::Key<#hash> }.into()
+}
+
 /// Declare a module to export internal types.
 /// ```rust
 /// use nject::{injectable, provider};

--- a/nject/Cargo.toml
+++ b/nject/Cargo.toml
@@ -15,6 +15,9 @@ repository = "https://github.com/nicolascotton/nject"
 [dependencies]
 nject-macro = { path = "../nject-macro", version = "0.4.5", optional = true }
 
+[dev-dependencies]
+trybuild = "1"
+
 [features]
 default = ["macro"]
 macro = ["dep:nject-macro"]

--- a/nject/src/lib.rs
+++ b/nject/src/lib.rs
@@ -5,7 +5,7 @@
 #[cfg(feature = "macro")]
 pub use nject_macro::{
     InjectableHelperAttr, ModuleHelperAttr, ProviderHelperAttr, ScopeHelperAttr, inject,
-    injectable, module, provider,
+    injectable, key, module, provider,
 };
 
 /// Provide a value for a specified type. Should be used with the `provide` macro for a better experience.
@@ -98,6 +98,138 @@ pub trait Injectable<'prov, Injecty, Provider> {
 /// ```
 pub trait Import<Module> {
     fn reference(&self) -> &Module;
+}
+
+/// A zero-cost wrapper that tags a `Value` with a `Name` type for named injection.
+///
+/// This allows multiple dependencies of the same type to coexist in a provider
+/// by distinguishing them via a phantom type tag. At runtime, `Named<Name, Value>`
+/// has the exact same memory layout as `Value` due to `#[repr(transparent)]`.
+///
+/// ```rust
+/// use nject::{injectable, provider, Named};
+///
+/// // Define zero-sized tag types
+/// struct DbUrl;
+/// struct ApiKey;
+///
+/// #[provider]
+/// #[provide(Named<DbUrl, String>, Named::new("postgres://localhost".into()))]
+/// #[provide(Named<ApiKey, String>, Named::new("secret-key".into()))]
+/// struct AppProvider;
+///
+/// let provider = AppProvider;
+/// let db_url: Named<DbUrl, String> = provider.provide();
+/// let api_key: Named<ApiKey, String> = provider.provide();
+/// assert_eq!(*db_url, "postgres://localhost");
+/// assert_eq!(*api_key, "secret-key");
+/// ```
+#[repr(transparent)]
+pub struct Named<Name, Value> {
+    /// The wrapped value.
+    pub value: Value,
+    _name: core::marker::PhantomData<Name>,
+}
+
+impl<Name, Value> Named<Name, Value> {
+    /// Create a new `Named` value with the given tag.
+    #[inline]
+    pub const fn new(value: Value) -> Self {
+        Self {
+            value,
+            _name: core::marker::PhantomData,
+        }
+    }
+
+    /// Unwrap the `Named` value, discarding the tag.
+    #[inline]
+    pub fn into_inner(self) -> Value {
+        self.value
+    }
+}
+
+impl<Name, Value: core::fmt::Debug> core::fmt::Debug for Named<Name, Value> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        self.value.fmt(f)
+    }
+}
+
+impl<Name, Value: Clone> Clone for Named<Name, Value> {
+    #[inline]
+    fn clone(&self) -> Self {
+        Self::new(self.value.clone())
+    }
+}
+
+impl<Name, Value: Copy> Copy for Named<Name, Value> {}
+
+impl<Name, Value: PartialEq> PartialEq for Named<Name, Value> {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.value == other.value
+    }
+}
+
+impl<Name, Value: Eq> Eq for Named<Name, Value> {}
+
+impl<Name, Value> core::ops::Deref for Named<Name, Value> {
+    type Target = Value;
+
+    #[inline]
+    fn deref(&self) -> &Value {
+        &self.value
+    }
+}
+
+impl<Name, Value> core::ops::DerefMut for Named<Name, Value> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Value {
+        &mut self.value
+    }
+}
+
+impl<Name, Value> From<Value> for Named<Name, Value> {
+    #[inline]
+    fn from(value: Value) -> Self {
+        Self::new(value)
+    }
+}
+
+/// A zero-sized type tag generated from a string key via FNV-1a hash.
+///
+/// Used with [`Named`] for string-based named injection. The `key!` macro
+/// provides convenient syntax: `key!("db_url")` expands to `Key<{HASH}>`.
+///
+/// ```rust
+/// use nject::{Named, Key, str_key_hash};
+///
+/// // These are equivalent:
+/// type A = Named<Key<{str_key_hash("db_url")}>, String>;
+///
+/// let a: A = Named::new("hello".into());
+/// assert_eq!(*a, "hello");
+/// ```
+pub struct Key<const K: u128>;
+
+/// Compute an FNV-1a 128-bit hash of a string at compile time.
+///
+/// This uses the same algorithm as the internal module hashing,
+/// producing a deterministic `u128` from any `&str`.
+pub const fn str_key_hash(s: &str) -> u128 {
+    // FNV-1a parameters for 128-bit
+    // https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function#FNV_hash_parameters
+    const FNV_OFFSET_BASIS: u128 = 0x6c62272e07bb014262b821756295c58d;
+    const FNV_PRIME: u128 = 0x00000100000001b3;
+
+    let bytes = s.as_bytes();
+    let mut hash = FNV_OFFSET_BASIS;
+    let mut i = 0;
+    while i < bytes.len() {
+        hash ^= bytes[i] as u128;
+        hash = hash.wrapping_mul(FNV_PRIME);
+        i += 1;
+    }
+    hash
 }
 
 /// For internal purposes only. Should not be used.

--- a/nject/tests/compile_fail.rs
+++ b/nject/tests/compile_fail.rs
@@ -1,0 +1,5 @@
+#[test]
+fn compile_fail_named_injection() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/compile_fail/*.rs");
+}

--- a/nject/tests/compile_fail/named_missing_provider.rs
+++ b/nject/tests/compile_fail/named_missing_provider.rs
@@ -1,0 +1,16 @@
+/// Provider does not provide Named<key!("db_url"), String>, so injection should fail.
+use nject::{injectable, provider};
+
+#[injectable]
+struct Service {
+    #[inject(named("db_url"))]
+    db_url: String,
+}
+
+#[provider]
+struct EmptyProvider;
+
+fn main() {
+    let provider = EmptyProvider;
+    let _svc: Service = provider.provide();
+}

--- a/nject/tests/compile_fail/named_missing_provider.stderr
+++ b/nject/tests/compile_fail/named_missing_provider.stderr
@@ -1,0 +1,30 @@
+error[E0277]: the trait bound `nject::Named<Key<70248561524979824689990959946592054517>, String>: Injectable<'_, nject::Named<Key<70248561524979824689990959946592054517>, String>, EmptyProvider>` is not satisfied
+  --> tests/compile_fail/named_missing_provider.rs:15:34
+   |
+15 |     let _svc: Service = provider.provide();
+   |                                  ^^^^^^^ unsatisfied trait bound
+   |
+   = help: the trait `Injectable<'_, nject::Named<Key<70248561524979824689990959946592054517>, String>, EmptyProvider>` is not implemented for `nject::Named<Key<70248561524979824689990959946592054517>, String>`
+help: the trait `Injectable<'prov, Service, NjectProvider>` is implemented for `Service`
+  --> tests/compile_fail/named_missing_provider.rs:4:1
+   |
+ 4 | #[injectable]
+   | ^^^^^^^^^^^^^
+note: required for `EmptyProvider` to implement `Provider<'_, nject::Named<Key<70248561524979824689990959946592054517>, String>>`
+  --> tests/compile_fail/named_missing_provider.rs:10:1
+   |
+10 | #[provider]
+   | ^^^^^^^^^^^
+note: required for `Service` to implement `Injectable<'_, Service, EmptyProvider>`
+  --> tests/compile_fail/named_missing_provider.rs:4:1
+   |
+ 4 | #[injectable]
+   | ^^^^^^^^^^^^^
+   = note: 1 redundant requirement hidden
+   = note: required for `EmptyProvider` to implement `Provider<'_, Service>`
+note: required by a bound in `EmptyProvider::provide`
+  --> tests/compile_fail/named_missing_provider.rs:10:1
+   |
+10 | #[provider]
+   | ^^^^^^^^^^^ required by this bound in `EmptyProvider::provide`
+   = note: this error originates in the attribute macro `injectable` which comes from the expansion of the attribute macro `provider` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/nject/tests/compile_fail/named_str_key_vs_type_tag.rs
+++ b/nject/tests/compile_fail/named_str_key_vs_type_tag.rs
@@ -1,0 +1,20 @@
+/// Provider provides Named<key!("db_url"), String> (string key) but
+/// injectable expects named(DbUrl) (type tag). These are different types.
+use nject::{Named, injectable, key, provider};
+
+struct DbUrl;
+
+#[injectable]
+struct Service {
+    #[inject(named(DbUrl))]
+    value: String,
+}
+
+#[provider]
+#[provide(Named<key!("db_url"), String>, Named::new("hello".into()))]
+struct MismatchedProvider;
+
+fn main() {
+    let provider = MismatchedProvider;
+    let _svc: Service = provider.provide();
+}

--- a/nject/tests/compile_fail/named_str_key_vs_type_tag.stderr
+++ b/nject/tests/compile_fail/named_str_key_vs_type_tag.stderr
@@ -1,0 +1,29 @@
+error[E0277]: the trait bound `nject::Named<DbUrl, String>: Injectable<'_, nject::Named<DbUrl, String>, MismatchedProvider>` is not satisfied
+  --> tests/compile_fail/named_str_key_vs_type_tag.rs:19:34
+   |
+19 |     let _svc: Service = provider.provide();
+   |                                  ^^^^^^^ the trait `Injectable<'_, nject::Named<DbUrl, String>, MismatchedProvider>` is not implemented for `nject::Named<DbUrl, String>`
+   |
+help: the trait `Injectable<'prov, Service, NjectProvider>` is implemented for `Service`
+  --> tests/compile_fail/named_str_key_vs_type_tag.rs:7:1
+   |
+ 7 | #[injectable]
+   | ^^^^^^^^^^^^^
+note: required for `MismatchedProvider` to implement `Provider<'_, nject::Named<DbUrl, String>>`
+  --> tests/compile_fail/named_str_key_vs_type_tag.rs:13:1
+   |
+13 | #[provider]
+   | ^^^^^^^^^^^
+note: required for `Service` to implement `Injectable<'_, Service, MismatchedProvider>`
+  --> tests/compile_fail/named_str_key_vs_type_tag.rs:7:1
+   |
+ 7 | #[injectable]
+   | ^^^^^^^^^^^^^
+   = note: 1 redundant requirement hidden
+   = note: required for `MismatchedProvider` to implement `Provider<'_, Service>`
+note: required by a bound in `MismatchedProvider::provide`
+  --> tests/compile_fail/named_str_key_vs_type_tag.rs:13:1
+   |
+13 | #[provider]
+   | ^^^^^^^^^^^ required by this bound in `MismatchedProvider::provide`
+   = note: this error originates in the attribute macro `injectable` which comes from the expansion of the attribute macro `provider` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/nject/tests/compile_fail/named_wrong_str_key.rs
+++ b/nject/tests/compile_fail/named_wrong_str_key.rs
@@ -1,0 +1,17 @@
+/// Provider provides Named<key!("foo"), String> but injectable expects named("bar").
+use nject::{Named, injectable, key, provider};
+
+#[injectable]
+struct Service {
+    #[inject(named("bar"))]
+    value: String,
+}
+
+#[provider]
+#[provide(Named<key!("foo"), String>, Named::new("hello".into()))]
+struct WrongKeyProvider;
+
+fn main() {
+    let provider = WrongKeyProvider;
+    let _svc: Service = provider.provide();
+}

--- a/nject/tests/compile_fail/named_wrong_str_key.stderr
+++ b/nject/tests/compile_fail/named_wrong_str_key.stderr
@@ -1,0 +1,30 @@
+error[E0277]: the trait bound `nject::Named<Key<35884545766218561747518507268035953522>, String>: Injectable<'_, nject::Named<Key<35884545766218561747518507268035953522>, String>, WrongKeyProvider>` is not satisfied
+  --> tests/compile_fail/named_wrong_str_key.rs:16:34
+   |
+16 |     let _svc: Service = provider.provide();
+   |                                  ^^^^^^^ unsatisfied trait bound
+   |
+   = help: the trait `Injectable<'_, nject::Named<Key<35884545766218561747518507268035953522>, String>, WrongKeyProvider>` is not implemented for `nject::Named<Key<35884545766218561747518507268035953522>, String>`
+help: the trait `Injectable<'prov, Service, NjectProvider>` is implemented for `Service`
+  --> tests/compile_fail/named_wrong_str_key.rs:4:1
+   |
+ 4 | #[injectable]
+   | ^^^^^^^^^^^^^
+note: required for `WrongKeyProvider` to implement `Provider<'_, nject::Named<Key<35884545766218561747518507268035953522>, String>>`
+  --> tests/compile_fail/named_wrong_str_key.rs:10:1
+   |
+10 | #[provider]
+   | ^^^^^^^^^^^
+note: required for `Service` to implement `Injectable<'_, Service, WrongKeyProvider>`
+  --> tests/compile_fail/named_wrong_str_key.rs:4:1
+   |
+ 4 | #[injectable]
+   | ^^^^^^^^^^^^^
+   = note: 1 redundant requirement hidden
+   = note: required for `WrongKeyProvider` to implement `Provider<'_, Service>`
+note: required by a bound in `WrongKeyProvider::provide`
+  --> tests/compile_fail/named_wrong_str_key.rs:10:1
+   |
+10 | #[provider]
+   | ^^^^^^^^^^^ required by this bound in `WrongKeyProvider::provide`
+   = note: this error originates in the attribute macro `injectable` which comes from the expansion of the attribute macro `provider` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/nject/tests/compile_fail/named_wrong_type_tag.rs
+++ b/nject/tests/compile_fail/named_wrong_type_tag.rs
@@ -1,0 +1,20 @@
+/// Provider provides Named<Foo, String> but injectable expects named(Bar).
+use nject::{Named, injectable, provider};
+
+struct Foo;
+struct Bar;
+
+#[injectable]
+struct Service {
+    #[inject(named(Bar))]
+    value: String,
+}
+
+#[provider]
+#[provide(Named<Foo, String>, Named::new("hello".into()))]
+struct WrongTagProvider;
+
+fn main() {
+    let provider = WrongTagProvider;
+    let _svc: Service = provider.provide();
+}

--- a/nject/tests/compile_fail/named_wrong_type_tag.stderr
+++ b/nject/tests/compile_fail/named_wrong_type_tag.stderr
@@ -1,0 +1,29 @@
+error[E0277]: the trait bound `nject::Named<Bar, String>: Injectable<'_, nject::Named<Bar, String>, WrongTagProvider>` is not satisfied
+  --> tests/compile_fail/named_wrong_type_tag.rs:19:34
+   |
+19 |     let _svc: Service = provider.provide();
+   |                                  ^^^^^^^ the trait `Injectable<'_, nject::Named<Bar, String>, WrongTagProvider>` is not implemented for `nject::Named<Bar, String>`
+   |
+help: the trait `Injectable<'prov, Service, NjectProvider>` is implemented for `Service`
+  --> tests/compile_fail/named_wrong_type_tag.rs:7:1
+   |
+ 7 | #[injectable]
+   | ^^^^^^^^^^^^^
+note: required for `WrongTagProvider` to implement `Provider<'_, nject::Named<Bar, String>>`
+  --> tests/compile_fail/named_wrong_type_tag.rs:13:1
+   |
+13 | #[provider]
+   | ^^^^^^^^^^^
+note: required for `Service` to implement `Injectable<'_, Service, WrongTagProvider>`
+  --> tests/compile_fail/named_wrong_type_tag.rs:7:1
+   |
+ 7 | #[injectable]
+   | ^^^^^^^^^^^^^
+   = note: 1 redundant requirement hidden
+   = note: required for `WrongTagProvider` to implement `Provider<'_, Service>`
+note: required by a bound in `WrongTagProvider::provide`
+  --> tests/compile_fail/named_wrong_type_tag.rs:13:1
+   |
+13 | #[provider]
+   | ^^^^^^^^^^^ required by this bound in `WrongTagProvider::provide`
+   = note: this error originates in the attribute macro `injectable` which comes from the expansion of the attribute macro `provider` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/nject/tests/named_injection.rs
+++ b/nject/tests/named_injection.rs
@@ -1,0 +1,435 @@
+use nject::{Key, Named, injectable, key, provider, str_key_hash};
+
+// --- Tag types (zero-sized, zero-cost markers) ---
+
+struct DbUrl;
+struct ApiKey;
+struct Primary;
+struct Secondary;
+
+#[test]
+fn named_type_is_zero_cost() {
+    // Named<Tag, T> should have the exact same size as T
+    assert_eq!(
+        core::mem::size_of::<Named<DbUrl, String>>(),
+        core::mem::size_of::<String>()
+    );
+    assert_eq!(
+        core::mem::size_of::<Named<ApiKey, i32>>(),
+        core::mem::size_of::<i32>()
+    );
+    // Zero-sized tags should not add any alignment padding
+    assert_eq!(
+        core::mem::align_of::<Named<DbUrl, String>>(),
+        core::mem::align_of::<String>()
+    );
+}
+
+#[test]
+fn named_deref_and_into_inner() {
+    let named: Named<DbUrl, String> = Named::new("hello".into());
+    // Deref
+    assert_eq!(&*named, "hello");
+    // into_inner
+    assert_eq!(named.into_inner(), "hello");
+}
+
+#[test]
+fn named_from_value() {
+    let named: Named<DbUrl, i32> = Named::from(42);
+    assert_eq!(*named, 42);
+}
+
+#[test]
+fn named_clone_and_eq() {
+    let a: Named<DbUrl, i32> = Named::new(42);
+    let b = a.clone();
+    assert_eq!(a, b);
+}
+
+#[injectable]
+#[derive(Debug, PartialEq)]
+struct ServiceWithDirectNamed(Named<DbUrl, String>, Named<ApiKey, String>);
+
+#[test]
+fn provide_direct_named_unnamed_struct() {
+    // Given
+    #[provider]
+    #[provide(Named<DbUrl, String>, Named::new("postgres://localhost".into()))]
+    #[provide(Named<ApiKey, String>, Named::new("secret-key".into()))]
+    struct DirectProvider;
+
+    let provider = DirectProvider;
+    // When
+    let svc: ServiceWithDirectNamed = provider.provide();
+    // Then
+    assert_eq!(*svc.0, "postgres://localhost");
+    assert_eq!(*svc.1, "secret-key");
+}
+
+#[injectable]
+#[derive(Debug, PartialEq)]
+struct ServiceWithDirectNamedFields {
+    db_url: Named<DbUrl, String>,
+    api_key: Named<ApiKey, String>,
+}
+
+#[test]
+fn provide_direct_named_named_struct() {
+    // Given
+    #[provider]
+    #[provide(Named<DbUrl, String>, Named::new("postgres://db".into()))]
+    #[provide(Named<ApiKey, String>, Named::new("my-api-key".into()))]
+    struct DirectFieldProvider;
+
+    let provider = DirectFieldProvider;
+    // When
+    let svc: ServiceWithDirectNamedFields = provider.provide();
+    // Then
+    assert_eq!(*svc.db_url, "postgres://db");
+    assert_eq!(*svc.api_key, "my-api-key");
+}
+
+#[injectable]
+#[derive(Debug, PartialEq)]
+struct ServiceWithNamedSugar {
+    #[inject(named(DbUrl))]
+    db_url: String,
+    #[inject(named(ApiKey))]
+    api_key: String,
+}
+
+#[test]
+fn provide_named_sugar_on_named_struct() {
+    // Given
+    #[provider]
+    #[provide(Named<DbUrl, String>, Named::new("postgres://sugar".into()))]
+    #[provide(Named<ApiKey, String>, Named::new("sugar-key".into()))]
+    struct SugarProvider;
+
+    let provider = SugarProvider;
+    // When
+    let svc: ServiceWithNamedSugar = provider.provide();
+    // Then — fields are plain Strings, no Named wrapper
+    assert_eq!(svc.db_url, "postgres://sugar");
+    assert_eq!(svc.api_key, "sugar-key");
+}
+
+#[injectable]
+#[derive(Debug, PartialEq)]
+struct ServiceWithNamedSugarTuple(
+    #[inject(named(DbUrl))] String,
+    #[inject(named(ApiKey))] String,
+);
+
+#[test]
+fn provide_named_sugar_on_tuple_struct() {
+    // Given
+    #[provider]
+    #[provide(Named<DbUrl, String>, Named::new("pg://tuple".into()))]
+    #[provide(Named<ApiKey, String>, Named::new("tuple-key".into()))]
+    struct TupleSugarProvider;
+
+    let provider = TupleSugarProvider;
+    // When
+    let svc: ServiceWithNamedSugarTuple = provider.provide();
+    // Then
+    assert_eq!(svc.0, "pg://tuple");
+    assert_eq!(svc.1, "tuple-key");
+}
+
+#[injectable]
+#[derive(Debug, PartialEq)]
+struct DualPorts {
+    #[inject(named(Primary))]
+    primary_port: u16,
+    #[inject(named(Secondary))]
+    secondary_port: u16,
+}
+
+#[test]
+fn provide_same_type_different_names_gives_different_values() {
+    // Given
+    #[provider]
+    #[provide(Named<Primary, u16>, Named::new(8080))]
+    #[provide(Named<Secondary, u16>, Named::new(9090))]
+    struct PortProvider;
+
+    let provider = PortProvider;
+    // When
+    let ports: DualPorts = provider.provide();
+    // Then
+    assert_eq!(ports.primary_port, 8080);
+    assert_eq!(ports.secondary_port, 9090);
+}
+
+#[test]
+fn provide_named_from_stateful_provider_fields() {
+    // Given
+    #[provider]
+    #[provide(Named<Primary, i32>, Named::new(self.primary))]
+    #[provide(Named<Secondary, i32>, Named::new(self.secondary))]
+    struct StatefulProvider {
+        primary: i32,
+        secondary: i32,
+    }
+
+    #[injectable]
+    #[derive(Debug, PartialEq)]
+    struct TwoInts {
+        #[inject(named(Primary))]
+        a: i32,
+        #[inject(named(Secondary))]
+        b: i32,
+    }
+
+    let provider = StatefulProvider {
+        primary: 111,
+        secondary: 222,
+    };
+    // When
+    let result: TwoInts = provider.provide();
+    // Then
+    assert_eq!(result.a, 111);
+    assert_eq!(result.b, 222);
+}
+
+#[injectable]
+#[derive(Debug, PartialEq)]
+struct RegularDep(#[inject(42)] i32);
+
+#[injectable]
+#[derive(Debug, PartialEq)]
+struct MixedService {
+    #[inject(named(DbUrl))]
+    db_url: String,
+    regular: RegularDep,
+}
+
+#[test]
+fn provide_mixed_named_and_regular_injection() {
+    // Given
+    #[provider]
+    #[provide(Named<DbUrl, String>, Named::new("postgres://mixed".into()))]
+    struct MixedProvider;
+
+    let provider = MixedProvider;
+    // When
+    let svc: MixedService = provider.provide();
+    // Then
+    assert_eq!(svc.db_url, "postgres://mixed");
+    assert_eq!(svc.regular, RegularDep(42));
+}
+
+#[test]
+fn key_type_is_zero_sized() {
+    assert_eq!(core::mem::size_of::<Key<0>>(), 0);
+    assert_eq!(core::mem::size_of::<Key<12345>>(), 0);
+    // Named<Key<H>, T> is same size as T
+    assert_eq!(
+        core::mem::size_of::<Named<Key<0>, String>>(),
+        core::mem::size_of::<String>()
+    );
+}
+
+#[test]
+fn str_key_hash_is_deterministic() {
+    assert_eq!(str_key_hash("db_url"), str_key_hash("db_url"));
+    assert_ne!(str_key_hash("db_url"), str_key_hash("api_key"));
+}
+
+#[test]
+fn key_macro_matches_str_key_hash() {
+    // key!("x") should produce the same type as Key<{str_key_hash("x")}>
+    fn assert_same_type<T>(_a: T, _b: T) {}
+    let a: Named<key!("db_url"), i32> = Named::new(1);
+    let b: Named<Key<{ str_key_hash("db_url") }>, i32> = Named::new(2);
+    assert_same_type(a, b);
+}
+
+#[injectable]
+#[derive(Debug, PartialEq)]
+struct StrKeyService {
+    #[inject(named("db_url"))]
+    db_url: String,
+    #[inject(named("api_key"))]
+    api_key: String,
+}
+
+#[test]
+fn provide_named_str_on_named_struct() {
+    // Given
+    #[provider]
+    #[provide(Named<key!("db_url"), String>, Named::new("pg://str-key".into()))]
+    #[provide(Named<key!("api_key"), String>, Named::new("str-secret".into()))]
+    struct StrKeyProvider;
+
+    let provider = StrKeyProvider;
+    // When
+    let svc: StrKeyService = provider.provide();
+    // Then
+    assert_eq!(svc.db_url, "pg://str-key");
+    assert_eq!(svc.api_key, "str-secret");
+}
+
+#[injectable]
+#[derive(Debug, PartialEq)]
+struct StrKeyTupleService(
+    #[inject(named("primary_port"))] u16,
+    #[inject(named("secondary_port"))] u16,
+);
+
+#[test]
+fn provide_named_str_on_tuple_struct() {
+    // Given
+    #[provider]
+    #[provide(Named<key!("primary_port"), u16>, Named::new(8080))]
+    #[provide(Named<key!("secondary_port"), u16>, Named::new(9090))]
+    struct StrKeyPortProvider;
+
+    let provider = StrKeyPortProvider;
+    // When
+    let svc: StrKeyTupleService = provider.provide();
+    // Then
+    assert_eq!(svc.0, 8080);
+    assert_eq!(svc.1, 9090);
+}
+
+#[test]
+fn provide_named_str_from_stateful_provider() {
+    // Given
+    #[provider]
+    #[provide(Named<key!("host"), String>, Named::new(self.host.clone()))]
+    #[provide(Named<key!("port"), u16>, Named::new(self.port))]
+    struct ConfigProvider {
+        host: String,
+        port: u16,
+    }
+
+    #[injectable]
+    #[derive(Debug, PartialEq)]
+    struct AppConfig {
+        #[inject(named("host"))]
+        host: String,
+        #[inject(named("port"))]
+        port: u16,
+    }
+
+    let provider = ConfigProvider {
+        host: "localhost".into(),
+        port: 3000,
+    };
+    // When
+    let config: AppConfig = provider.provide();
+    // Then
+    assert_eq!(config.host, "localhost");
+    assert_eq!(config.port, 3000);
+}
+
+#[injectable]
+#[derive(Debug, PartialEq)]
+struct FullyMixedService {
+    #[inject(named("connection_string"))]
+    conn: String,
+    #[inject(named(Primary))]
+    primary_id: u32,
+    regular: RegularDep,
+}
+
+#[test]
+fn provide_mixed_str_key_type_tag_and_regular() {
+    // Given
+    #[provider]
+    #[provide(Named<key!("connection_string"), String>, Named::new("pg://mixed-all".into()))]
+    #[provide(Named<Primary, u32>, Named::new(999))]
+    struct FullyMixedProvider;
+
+    let provider = FullyMixedProvider;
+    // When
+    let svc: FullyMixedService = provider.provide();
+    // Then
+    assert_eq!(svc.conn, "pg://mixed-all");
+    assert_eq!(svc.primary_id, 999);
+    assert_eq!(svc.regular, RegularDep(42));
+}
+
+#[injectable]
+#[derive(Debug, PartialEq)]
+struct SameKeyDifferentTypes {
+    #[inject(named("value"))]
+    as_string: String,
+    #[inject(named("value"))]
+    as_int: i32,
+    #[inject(named("value"))]
+    as_float: f64,
+}
+
+#[test]
+fn provide_same_str_key_different_types_resolves_independently() {
+    // Given — same key "value" but three different types
+    #[provider]
+    #[provide(Named<key!("value"), String>, Named::new("hello".into()))]
+    #[provide(Named<key!("value"), i32>, Named::new(42))]
+    #[provide(Named<key!("value"), f64>, Named::new(3.14))]
+    struct SameKeyProvider;
+
+    let provider = SameKeyProvider;
+    // When
+    let svc: SameKeyDifferentTypes = provider.provide();
+    // Then — each field gets the value for its own type
+    assert_eq!(svc.as_string, "hello");
+    assert_eq!(svc.as_int, 42);
+    assert_eq!((svc.as_float - 3.14).abs() < f64::EPSILON, true);
+}
+
+#[injectable]
+#[derive(Debug, PartialEq)]
+struct SameKeyDifferentTypesTuple(
+    #[inject(named("data"))] String,
+    #[inject(named("data"))] u64,
+    #[inject(named("data"))] bool,
+);
+
+#[test]
+fn provide_same_str_key_different_types_tuple_resolves_independently() {
+    // Given
+    #[provider]
+    #[provide(Named<key!("data"), String>, Named::new("world".into()))]
+    #[provide(Named<key!("data"), u64>, Named::new(999))]
+    #[provide(Named<key!("data"), bool>, Named::new(true))]
+    struct SameKeyTupleProvider;
+
+    let provider = SameKeyTupleProvider;
+    // When
+    let svc: SameKeyDifferentTypesTuple = provider.provide();
+    // Then
+    assert_eq!(svc.0, "world");
+    assert_eq!(svc.1, 999);
+    assert_eq!(svc.2, true);
+}
+
+// Same type-tag, different types — verify same behavior with type tags
+#[injectable]
+#[derive(Debug, PartialEq)]
+struct SameTagDifferentTypes {
+    #[inject(named(Primary))]
+    as_string: String,
+    #[inject(named(Primary))]
+    as_int: i32,
+}
+
+#[test]
+fn provide_same_type_tag_different_types_resolves_independently() {
+    // Given
+    #[provider]
+    #[provide(Named<Primary, String>, Named::new("tagged".into()))]
+    #[provide(Named<Primary, i32>, Named::new(77))]
+    struct SameTagProvider;
+
+    let provider = SameTagProvider;
+    // When
+    let svc: SameTagDifferentTypes = provider.provide();
+    // Then
+    assert_eq!(svc.as_string, "tagged");
+    assert_eq!(svc.as_int, 77);
+}


### PR DESCRIPTION

## Summary

- Add zero-cost `Named<Tag, Value>` wrapper type for distinguishing multiple dependencies of the same type via phantom type tags
- Add `Key<const K: u128>` type and `key!("str")` proc macro for string-literal-based named injection without defining ZST tags
- Add `#[inject(named(Tag))]` and `#[inject(named("str"))]` field attribute sugar that resolves through `Named` but keeps fields as plain types
- Add `trybuild` compile-fail tests to verify misuse is caught at compile time

## Motivation

In nject, dependencies are resolved by type. If a struct needs two `String` fields (e.g., a database URL and an API key), there was no way to provide different values — both would resolve to the same `Provider<'prov, String>` impl. Named injection solves this by wrapping the type with a phantom tag, creating distinct types at zero runtime cost.


## Design

### Core types (`nject/src/lib.rs`)

```rust
#[repr(transparent)]
pub struct Named<Name, Value> { pub value: Value, _name: PhantomData<Name> }

pub struct Key<const K: u128>;          // ZST from string hash
pub const fn str_key_hash(s: &str) -> u128;  // compile-time FNV-1a
```

`Named<Tag, T>` is `#[repr(transparent)]` — identical layout to `T`. `Key<K>` is zero-sized. After monomorphization and inlining, the wrapper vanishes entirely.

### Three usage patterns

**Pattern A — Type tag (explicit ZST):**
```rust
struct DbUrl;
struct ApiKey;

#[injectable]
struct Service {
    #[inject(named(DbUrl))]
    db_url: String,
    #[inject(named(ApiKey))]
    api_key: String,
}

#[provider]
#[provide(Named<DbUrl, String>, Named::new("postgres://...".into()))]
#[provide(Named<ApiKey, String>, Named::new("secret".into()))]
struct AppProvider;
```

**Pattern B — String key (`key!` macro):**
```rust
#[injectable]
struct Service {
    #[inject(named("db_url"))]
    db_url: String,
    #[inject(named("api_key"))]
    api_key: String,
}

#[provider]
#[provide(Named<key!("db_url"), String>, Named::new("postgres://...".into()))]
#[provide(Named<key!("api_key"), String>, Named::new("secret".into()))]
struct AppProvider;
```

**Pattern C — Direct (no macro sugar):**
```rust
#[injectable]
struct Service(Named<DbUrl, String>, Named<ApiKey, String>);
```

### How it works

The `#[inject(named(Tag))]` attribute on a field of type `T`:
- Changes the provider bound from `Provider<'prov, T>` to `Provider<'prov, Named<Tag, T>>`
- Generates `Named::<Tag, T>::into_inner(provider.provide())` to unwrap back to `T`
- The field remains a plain `T` — no wrapper stored at runtime

For string keys, `named("key")` and `key!("key")` both compute the same FNV-1a 128-bit hash at compile time using constant evaluation, producing matching `Key<HASH>` types.


## Macro expansion walkthrough (`cargo expand`)

Given this input:

```rust
use nject::{Named, injectable, key, provider};

struct DbUrl;

#[injectable]
struct Service {
    #[inject(named(DbUrl))]
    db_url: String,
    #[inject(named("api_key"))]
    api_key: String,
}

#[provider]
#[provide(Named<DbUrl, String>, Named::new("postgres://localhost".into()))]
#[provide(Named<key!("api_key"), String>, Named::new("secret".into()))]
struct AppProvider;

fn main() {
    let provider = AppProvider;
    let svc: Service = provider.provide();
}
```

`cargo expand` produces the following (cleaned up for readability):

### 1. `Service` — the injectable struct

The struct itself is unchanged. The macro generates an `Injectable` impl:

```rust
struct Service {
    db_url: String,     // plain String, no wrapper
    api_key: String,    // plain String, no wrapper
}

impl<'prov, NjectProvider> nject::Injectable<'prov, Service, NjectProvider>
for Service
where
    //                        vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv  type-tag variant
    NjectProvider: nject::Provider<'prov, nject::Named<DbUrl, String>>
    //                        vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv  string-key variant
                 + nject::Provider<'prov, nject::Named<nject::Key<128119411419132462630929301103536684623>, String>>,
{
    #[inline]
    fn inject(provider: &'prov NjectProvider) -> Service {
        Service {
            // Type tag: resolves Named<DbUrl, String>, then unwraps
            db_url: nject::Named::<DbUrl, String>::into_inner(provider.provide()),

            // String key: "api_key" hashed to u128, resolves Named<Key<HASH>, String>, then unwraps
            api_key: nject::Named::<
                nject::Key<128119411419132462630929301103536684623>,
                String,
            >::into_inner(provider.provide()),
        }
    }
}
```

**Key observations:**
- The `where` clause requires `NjectProvider` to implement `Provider` for each `Named<Tag, T>` — this is how the compiler enforces that every named dependency is satisfied.
- `named(DbUrl)` becomes `Named<DbUrl, String>` (the ZST struct as tag).
- `named("api_key")` becomes `Named<Key<128119411419132462630929301103536684623>, String>` (the FNV-1a hash of `"api_key"` as a const u128).
- `into_inner()` unwraps the `Named` wrapper, so the field stores a plain `String`.

### 2. `AppProvider` — the provider struct

The provider gets a generic `Provider<Njecty>` impl (for any injectable type), plus specific impls for each `#[provide(...)]`:

```rust
// Generic: delegates to Injectable::inject for any type that implements Injectable
impl<'prov, Njecty> nject::Provider<'prov, Njecty> for AppProvider
where
    Njecty: nject::Injectable<'prov, Njecty, AppProvider>,
{
    #[inline]
    fn provide(&'prov self) -> Njecty {
        Njecty::inject(self)
    }
}

// Specific: provides Named<DbUrl, String> from type-tag
impl<'prov> nject::Provider<'prov, Named<DbUrl, String>> for AppProvider {
    #[inline]
    fn provide(&'prov self) -> Named<DbUrl, String> {
        Named::new("postgres://localhost".into())
    }
}

// Specific: provides Named<Key<HASH>, String> from string-key
impl<'prov> nject::Provider<'prov, Named<Key<128119411419132462630929301103536684623>, String>>
for AppProvider {
    #[inline]
    fn provide(&'prov self) -> Named<Key<128119411419132462630929301103536684623>, String> {
        Named::new("secret".into())
    }
}
```

Fixes #49 