### PR TITLE
feat: init format

### DIFF
--- a/nject-macro/src/init.rs
+++ b/nject-macro/src/init.rs
@@ -1,0 +1,273 @@
+use proc_macro::TokenStream;
+use quote::{format_ident, quote};
+use syn::{
+    GenericArgument, Ident, Lifetime, Token, Type,
+    parse::{Parse, ParseStream},
+    punctuated::Punctuated,
+};
+
+/// Two forms:
+/// - Expression: `init!(M1, M2, M3)` -> block expression (owned modules only)
+/// - Block:
+///   ```ignore
+///   init! {
+///       let [mut] name [: Type] = M1, M2;
+///       let [mut] name [: Type] = M3;
+///   }
+///   ```
+///   For statements in enclosing scope (supports borrowing, multiple declarations)
+enum InitInput {
+    Expr { modules: Vec<Type> },
+    Block { declarations: Vec<LetDecl> },
+}
+
+struct LetDecl {
+    is_mut: bool,
+    ident: Ident,
+    ty: Option<Type>,
+    modules: Vec<Type>,
+}
+
+impl Parse for InitInput {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        if input.peek(Token![let]) {
+            let mut declarations = Vec::new();
+            while !input.is_empty() {
+                declarations.push(input.parse::<LetDecl>()?);
+                // Consume optional semicolon between/after declarations
+                while !input.is_empty() && input.peek(Token![;]) {
+                    input.parse::<Token![;]>()?;
+                }
+            }
+            Ok(InitInput::Block { declarations })
+        } else {
+            let modules = Punctuated::<Type, Token![,]>::parse_terminated(input)?;
+            Ok(InitInput::Expr {
+                modules: modules.into_iter().collect(),
+            })
+        }
+    }
+}
+
+impl Parse for LetDecl {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        input.parse::<Token![let]>()?;
+        let is_mut = if input.peek(Token![mut]) {
+            input.parse::<Token![mut]>()?;
+            true
+        } else {
+            false
+        };
+        let ident = input.parse::<Ident>()?;
+        let ty = if input.peek(Token![:]) {
+            input.parse::<Token![:]>()?;
+            Some(input.parse::<Type>()?)
+        } else {
+            None
+        };
+        input.parse::<Token![=]>()?;
+        let modules = Punctuated::<Type, Token![,]>::parse_separated_nonempty(input)?;
+        Ok(LetDecl {
+            is_mut,
+            ident,
+            ty,
+            modules: modules.into_iter().collect(),
+        })
+    }
+}
+
+fn collect_lifetimes_from_type(ty: &Type, lifetimes: &mut Vec<Lifetime>) {
+    match ty {
+        Type::Path(p) => {
+            for segment in &p.path.segments {
+                if let syn::PathArguments::AngleBracketed(args) = &segment.arguments {
+                    for arg in &args.args {
+                        match arg {
+                            GenericArgument::Lifetime(lt) => {
+                                if !lifetimes.iter().any(|l| l.ident == lt.ident) {
+                                    lifetimes.push(lt.clone());
+                                }
+                            }
+                            GenericArgument::Type(t) => {
+                                collect_lifetimes_from_type(t, lifetimes);
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+            }
+        }
+        Type::Reference(r) => {
+            if let Some(lt) = &r.lifetime {
+                if !lifetimes.iter().any(|l| l.ident == lt.ident) {
+                    lifetimes.push(lt.clone());
+                }
+            }
+            collect_lifetimes_from_type(&r.elem, lifetimes);
+        }
+        _ => {}
+    }
+}
+
+/// Generate the intermediate struct definitions and let-bindings for a chain of N modules.
+/// `name_prefix` is used to create unique identifiers when multiple `init!` calls coexist.
+fn gen_chain(
+    modules: &[Type],
+    name_prefix: &str,
+) -> (
+    Vec<proc_macro2::TokenStream>,
+    Vec<proc_macro2::TokenStream>,
+    Ident,
+) {
+    let init_ident = format_ident!("__NjectInit_{}", name_prefix);
+    let init_var = format_ident!("__nject_init_{}", name_prefix);
+
+    let mut struct_defs = vec![quote! {
+        #[nject::provider]
+        #[allow(non_camel_case_types)]
+        struct #init_ident;
+    }];
+
+    let mut let_bindings = vec![quote! {
+        let #init_var = #init_ident;
+    }];
+
+    let mut last_var = init_var.clone();
+
+    for i in 0..modules.len() - 1 {
+        let step_ident = format_ident!("__NjectInitStep_{}_{}", name_prefix, i);
+        let step_modules = &modules[0..=i];
+
+        // Collect unique lifetimes from all module types in this step
+        let mut lifetimes = Vec::new();
+        for m in step_modules {
+            collect_lifetimes_from_type(m, &mut lifetimes);
+        }
+
+        let generic_params = if lifetimes.is_empty() {
+            quote! {}
+        } else {
+            quote! { <#(#lifetimes),*> }
+        };
+
+        let import_fields = step_modules.iter().map(|m| {
+            quote! { #[import] #m }
+        });
+
+        struct_defs.push(quote! {
+            #[nject::injectable]
+            #[nject::provider]
+            #[allow(non_camel_case_types)]
+            struct #step_ident #generic_params (#(#import_fields),*);
+        });
+
+        let var_ident = format_ident!("__nject_{}_s{}", name_prefix, i);
+
+        let_bindings.push(quote! {
+            let #var_ident = #last_var.provide::<#step_ident>();
+        });
+
+        last_var = var_ident;
+    }
+
+    (struct_defs, let_bindings, last_var)
+}
+
+pub(crate) fn handle_init(item: TokenStream) -> syn::Result<TokenStream> {
+    let input = syn::parse::<InitInput>(item)?;
+
+    match input {
+        InitInput::Expr { modules } => {
+            if modules.is_empty() {
+                return Err(syn::Error::new(
+                    proc_macro2::Span::call_site(),
+                    "init! requires at least one module type",
+                ));
+            }
+            handle_init_expr(&modules)
+        }
+        InitInput::Block { declarations } => {
+            if declarations.is_empty() {
+                return Err(syn::Error::new(
+                    proc_macro2::Span::call_site(),
+                    "init! block requires at least one let declaration",
+                ));
+            }
+            handle_init_block(&declarations)
+        }
+    }
+}
+
+/// Expression form: `init!(M1, M2)` -> block expression
+fn handle_init_expr(modules: &[Type]) -> syn::Result<TokenStream> {
+    if modules.len() == 1 {
+        let output = quote! {
+            {
+                #[nject::provider]
+                struct __NjectInitProvider;
+                __NjectInitProvider.provide()
+            }
+        };
+        return Ok(output.into());
+    }
+
+    let (struct_defs, let_bindings, last_var) = gen_chain(modules, "expr");
+
+    let output = quote! {
+        {
+            #(#struct_defs)*
+            #(#let_bindings)*
+            #last_var.provide()
+        }
+    };
+
+    Ok(output.into())
+}
+
+/// Block form: `init! { let name: Type = M1, M2; ... }` -> statements in enclosing scope
+fn handle_init_block(declarations: &[LetDecl]) -> syn::Result<TokenStream> {
+    let mut all_tokens = Vec::new();
+
+    for decl in declarations {
+        if decl.modules.is_empty() {
+            return Err(syn::Error::new(
+                proc_macro2::Span::call_site(),
+                "each let declaration requires at least one module type",
+            ));
+        }
+
+        let mutability = if decl.is_mut {
+            quote! { mut }
+        } else {
+            quote! {}
+        };
+
+        let ty_annotation = match &decl.ty {
+            Some(t) => quote! { : #t },
+            None => quote! {},
+        };
+
+        let ident = &decl.ident;
+        let name_prefix = ident.to_string();
+
+        if decl.modules.len() == 1 {
+            let init_ident = format_ident!("__NjectInit_{}", name_prefix);
+            all_tokens.push(quote! {
+                #[nject::provider]
+                #[allow(non_camel_case_types)]
+                struct #init_ident;
+                let #mutability #ident #ty_annotation = #init_ident.provide();
+            });
+        } else {
+            let (struct_defs, let_bindings, last_var) = gen_chain(&decl.modules, &name_prefix);
+            all_tokens.push(quote! {
+                #(#struct_defs)*
+                #(#let_bindings)*
+                let #mutability #ident #ty_annotation = #last_var.provide();
+            });
+        }
+    }
+
+    let output = quote! { #(#all_tokens)* };
+    Ok(output.into())
+}

--- a/nject-macro/src/lib.rs
+++ b/nject-macro/src/lib.rs
@@ -1,10 +1,12 @@
 #![allow(clippy::needless_doctest_main)]
 #![doc = include_str!("../README.md")]
 mod core;
+mod init;
 mod inject;
 mod injectable;
 mod module;
 mod provider;
+use init::handle_init;
 use inject::handle_inject;
 use injectable::handle_injectable;
 use module::handle_module;
@@ -160,4 +162,72 @@ pub fn provider(_attr: TokenStream, item: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn module(attr: TokenStream, item: TokenStream) -> TokenStream {
     handle_module(attr, item).unwrap_or_else(|e| e.to_compile_error().into())
+}
+
+/// Simplify provider initialisation by automatically creating the chain of intermediate providers.
+///
+/// Instead of manually defining intermediate providers and chaining `.provide()` calls,
+/// use `init!` with the list of module types in dependency order.
+///
+/// # Expression form
+///
+/// Returns the provider as an owned value. Works with struct-level `#[export]` (owned values).
+///
+/// ```rust
+/// use nject::{init, injectable, module, provider};
+///
+/// #[injectable]
+/// #[module]
+/// #[export(i32, 42)]
+/// struct ConfigModule;
+///
+/// #[injectable]
+/// #[module]
+/// #[export(String, |x: i32| format!("value: {}", x))]
+/// struct FormatModule;
+///
+/// #[injectable]
+/// #[provider]
+/// struct AppProvider(#[import] ConfigModule, #[import] FormatModule);
+///
+/// let provider: AppProvider = init!(ConfigModule, FormatModule);
+/// let greeting: String = provider.provide();
+/// assert_eq!(greeting, "value: 42");
+/// ```
+///
+/// # Block form
+///
+/// Expands `let` declarations into the enclosing scope, keeping intermediate providers alive.
+/// This supports field-level `#[export]` (references) and multiple declarations (like `lazy_static!`).
+///
+/// ```rust
+/// use nject::{init, injectable, module, provider};
+///
+/// #[derive(Debug)]
+/// #[injectable]
+/// struct Secret(#[inject(42)] i32);
+///
+/// #[injectable]
+/// #[module]
+/// struct SecretModule {
+///     #[export]
+///     secret: Secret,
+/// }
+///
+/// #[injectable]
+/// struct Consumer<'a>(&'a Secret);
+///
+/// #[injectable]
+/// #[provider]
+/// struct AppProvider(#[import] SecretModule);
+///
+/// init! {
+///     let provider: AppProvider = SecretModule;
+/// }
+/// let consumer: Consumer = provider.provide();
+/// assert_eq!(consumer.0.0, 42);
+/// ```
+#[proc_macro]
+pub fn init(item: TokenStream) -> TokenStream {
+    handle_init(item).unwrap_or_else(|e| e.to_compile_error().into())
 }

--- a/nject/examples/init.rs
+++ b/nject/examples/init.rs
@@ -1,0 +1,74 @@
+//! Example: Simplifying provider initialisation with `init!`
+//!
+//! Two forms are available:
+//! - Expression: `let p: Provider = init!(M1, M2);` — for modules with owned exports
+//! - Block: `init! { let p: Provider = M1, M2; }` — also supports borrowed exports
+
+use nject::{init, injectable, module, provider};
+
+// --- Module definitions ---
+
+/// A configuration module that exports a database port number (owned).
+#[injectable]
+#[module]
+#[export(u16, 5432)]
+struct DbConfigModule;
+
+/// A formatting module that exports a connection string (owned).
+/// It depends on `u16` (the port) exported by `DbConfigModule`.
+#[injectable]
+#[module]
+#[export(String, |port: u16| format!("postgres://localhost:{}", port))]
+struct ConnectionModule;
+
+// --- An injectable service that uses the connection string ---
+
+#[injectable]
+struct DbService {
+    connection_string: String,
+}
+
+// --- Modules with field-level exports (references) ---
+
+#[derive(Debug)]
+#[injectable]
+struct Secret(#[inject(42)] i32);
+
+#[injectable]
+#[module]
+struct SecretModule {
+    #[export]
+    secret: Secret,
+}
+
+#[injectable]
+struct SecretConsumer<'a>(&'a Secret);
+
+// --- Providers ---
+
+#[injectable]
+#[provider]
+struct AppProvider(#[import] DbConfigModule, #[import] ConnectionModule);
+
+#[injectable]
+#[provider]
+struct SecretProvider(#[import] SecretModule);
+
+fn main() {
+    // Works great when module exports are owned values (struct-level #[export]).
+    let provider: AppProvider = init!(DbConfigModule, ConnectionModule);
+
+    let svc: DbService = provider.provide();
+    println!("[expr]  Connection: {}", svc.connection_string);
+    assert_eq!(svc.connection_string, "postgres://localhost:5432");
+
+    // Required when modules use field-level #[export] (which produces references).
+    // Supports multiple declarations, like lazy_static!.
+    init! {
+        let secret_provider: SecretProvider = SecretModule;
+    }
+
+    let consumer: SecretConsumer = secret_provider.provide();
+    println!("[block] Secret value: {}", consumer.0.0);
+    assert_eq!(consumer.0.0, 42);
+}

--- a/nject/src/lib.rs
+++ b/nject/src/lib.rs
@@ -4,7 +4,7 @@
 
 #[cfg(feature = "macro")]
 pub use nject_macro::{
-    InjectableHelperAttr, ModuleHelperAttr, ProviderHelperAttr, ScopeHelperAttr, inject,
+    InjectableHelperAttr, ModuleHelperAttr, ProviderHelperAttr, ScopeHelperAttr, init, inject,
     injectable, module, provider,
 };
 

--- a/nject/tests/init.rs
+++ b/nject/tests/init.rs
@@ -1,0 +1,475 @@
+use nject::{init, injectable, module, provider};
+
+#[test]
+fn init_expr_with_single_module_should_provide_target() {
+    #[injectable]
+    #[module]
+    #[export(i32, 42)]
+    struct FooModule;
+
+    #[injectable]
+    #[provider]
+    struct Provider(#[import] FooModule);
+
+    let provider: Provider = init!(FooModule);
+
+    let value: i32 = provider.provide();
+    assert_eq!(value, 42);
+}
+
+#[test]
+fn init_expr_with_two_modules_should_chain_dependencies() {
+    #[injectable]
+    #[module]
+    #[export(i32, 42)]
+    struct ConfigModule;
+
+    #[injectable]
+    #[module]
+    #[export(String, |x: i32| format!("value: {}", x))]
+    struct FormatModule;
+
+    #[injectable]
+    #[provider]
+    struct AppProvider(#[import] ConfigModule, #[import] FormatModule);
+
+    let provider: AppProvider = init!(ConfigModule, FormatModule);
+
+    let greeting: String = provider.provide();
+    assert_eq!(greeting, "value: 42");
+}
+
+#[test]
+fn init_expr_with_three_modules_should_chain_all_dependencies() {
+    #[injectable]
+    #[module]
+    #[export(i32, 100)]
+    struct BaseModule;
+
+    #[injectable]
+    #[module]
+    #[export(u32, |x: i32| x as u32 + 1)]
+    struct MiddleModule;
+
+    #[injectable]
+    #[module]
+    #[export(String, |x: u32| format!("result: {}", x))]
+    struct TopModule;
+
+    #[injectable]
+    #[provider]
+    struct Provider(
+        #[import] BaseModule,
+        #[import] MiddleModule,
+        #[import] TopModule,
+    );
+
+    let provider: Provider = init!(BaseModule, MiddleModule, TopModule);
+
+    let result: String = provider.provide();
+    assert_eq!(result, "result: 101");
+}
+
+#[test]
+fn init_expr_with_independent_modules_should_work() {
+    #[injectable]
+    #[module]
+    #[export(i32, 10)]
+    struct ModuleA;
+
+    #[injectable]
+    #[module]
+    #[export(u32, 20)]
+    struct ModuleB;
+
+    #[injectable]
+    #[provider]
+    struct Provider(#[import] ModuleA, #[import] ModuleB);
+
+    let provider: Provider = init!(ModuleA, ModuleB);
+
+    let a: i32 = provider.provide();
+    let b: u32 = provider.provide();
+    assert_eq!(a, 10);
+    assert_eq!(b, 20);
+}
+
+// ── Block form: init! { let name = M1, M2; } ───────────────────────
+
+#[test]
+fn init_block_with_single_module_should_provide_target() {
+    #[injectable]
+    #[module]
+    #[export(i32, 99)]
+    struct SingleModule;
+
+    #[injectable]
+    #[provider]
+    struct Provider(#[import] SingleModule);
+
+    init! {
+        let provider: Provider = SingleModule;
+    }
+
+    let value: i32 = provider.provide();
+    assert_eq!(value, 99);
+}
+
+#[test]
+fn init_block_with_two_modules_should_chain_dependencies() {
+    #[injectable]
+    #[module]
+    #[export(i32, 7)]
+    struct NumModule;
+
+    #[injectable]
+    #[module]
+    #[export(String, |x: i32| format!("num={}", x))]
+    struct FmtModule;
+
+    #[injectable]
+    #[provider]
+    struct Provider(#[import] NumModule, #[import] FmtModule);
+
+    init! {
+        let provider: Provider = NumModule, FmtModule;
+    }
+
+    let s: String = provider.provide();
+    assert_eq!(s, "num=7");
+}
+
+#[test]
+fn init_block_without_type_annotation_should_infer_type() {
+    #[injectable]
+    #[module]
+    #[export(i32, 55)]
+    struct InferModule;
+
+    #[injectable]
+    #[provider]
+    struct Provider(#[import] InferModule);
+
+    init! {
+        let provider: Provider = InferModule;
+    }
+
+    let value: i32 = provider.provide();
+    assert_eq!(value, 55);
+}
+
+#[test]
+fn init_block_mut_should_allow_mutation() {
+    #[injectable]
+    #[module]
+    #[export(i32, 1)]
+    struct MutModule;
+
+    #[injectable]
+    #[provider]
+    struct Provider(#[import] MutModule);
+
+    init! {
+        let mut provider: Provider = MutModule;
+    }
+    let value: i32 = provider.provide();
+    assert_eq!(value, 1);
+    // Re-assign to prove mutability
+    init! {
+        let provider2: Provider = MutModule;
+    }
+    provider = provider2;
+    let value2: i32 = provider.provide();
+    assert_eq!(value2, 1);
+}
+
+#[test]
+fn init_block_with_field_export_borrowing_should_work() {
+    // Field-level #[export] produces &'prov T references, which borrow
+    // from the intermediate provider. The block form keeps the
+    // intermediates alive in the enclosing scope.
+
+    #[derive(Debug, PartialEq)]
+    #[injectable]
+    struct InternalDep(#[inject(123)] i32);
+
+    #[derive(Debug, PartialEq)]
+    #[injectable]
+    pub struct Facade<'a>(&'a InternalDep);
+
+    #[injectable]
+    #[module]
+    struct DepModule {
+        #[export]
+        hidden: InternalDep,
+    }
+
+    #[injectable]
+    #[provider]
+    struct Provider(#[import] DepModule);
+
+    init! {
+        let provider: Provider = DepModule;
+    }
+
+    let facade: Facade = provider.provide();
+    assert_eq!(facade.0.0, 123);
+}
+
+#[test]
+fn init_block_with_cross_module_borrowing_should_work() {
+    // Module A exports a field (reference).
+    // Module B depends on Module A's export.
+    // The block form keeps Module A's intermediate provider alive
+    // so the references remain valid.
+
+    #[derive(Debug, PartialEq)]
+    #[injectable]
+    struct Config(#[inject(42)] i32);
+
+    #[injectable]
+    #[module]
+    struct ConfigModule {
+        #[export]
+        config: Config,
+    }
+
+    #[derive(Debug, PartialEq)]
+    #[injectable]
+    struct Service<'a>(&'a Config);
+
+    #[injectable]
+    #[module]
+    struct ServiceModule<'a> {
+        #[export]
+        svc: Service<'a>,
+    }
+
+    #[injectable]
+    #[provider]
+    struct AppProvider<'a>(#[import] ConfigModule, #[import] ServiceModule<'a>);
+
+    init! {
+        let provider: AppProvider<'_> = ConfigModule, ServiceModule;
+    }
+
+    let svc: Service = provider.provide();
+    assert_eq!(svc.0.0, 42);
+}
+
+#[test]
+fn init_block_with_multiple_declarations_should_work() {
+    #[injectable]
+    #[module]
+    #[export(i32, 10)]
+    struct AlphaModule;
+
+    #[injectable]
+    #[module]
+    #[export(u32, 20)]
+    struct BetaModule;
+
+    #[injectable]
+    #[provider]
+    struct AlphaProvider(#[import] AlphaModule);
+
+    #[injectable]
+    #[provider]
+    struct BetaProvider(#[import] BetaModule);
+
+    init! {
+        let alpha: AlphaProvider = AlphaModule;
+        let beta: BetaProvider = BetaModule;
+    }
+
+    let a: i32 = alpha.provide();
+    let b: u32 = beta.provide();
+    assert_eq!(a, 10);
+    assert_eq!(b, 20);
+}
+
+#[test]
+fn init_block_with_multiple_chained_declarations_should_work() {
+    // Multiple declarations where each has its own dependency chain.
+
+    #[injectable]
+    #[module]
+    #[export(i32, 10)]
+    struct NumModule;
+
+    #[injectable]
+    #[module]
+    #[export(String, |x: i32| format!("n={}", x))]
+    struct FmtModule;
+
+    #[injectable]
+    #[module]
+    #[export(u64, 999)]
+    struct IdModule;
+
+    #[injectable]
+    #[provider]
+    struct FmtProvider(#[import] NumModule, #[import] FmtModule);
+
+    #[injectable]
+    #[provider]
+    struct IdProvider(#[import] IdModule);
+
+    init! {
+        let fmt_prov: FmtProvider = NumModule, FmtModule;
+        let id_prov: IdProvider = IdModule;
+    }
+
+    let s: String = fmt_prov.provide();
+    let id: u64 = id_prov.provide();
+    assert_eq!(s, "n=10");
+    assert_eq!(id, 999);
+}
+
+#[test]
+fn init_block_with_multiple_declarations_and_borrowing_should_work() {
+    // Multiple declarations where one uses field-level exports (borrowing).
+
+    #[derive(Debug, PartialEq)]
+    #[injectable]
+    struct DbPool(#[inject(5)] i32);
+
+    #[injectable]
+    #[module]
+    struct DbModule {
+        #[export]
+        pool: DbPool,
+    }
+
+    #[derive(Debug, PartialEq)]
+    #[injectable]
+    struct Repo<'a>(&'a DbPool);
+
+    #[injectable]
+    #[provider]
+    struct DbProvider(#[import] DbModule);
+
+    #[injectable]
+    #[module]
+    #[export(u16, 8080)]
+    struct HttpModule;
+
+    #[injectable]
+    #[provider]
+    struct HttpProvider(#[import] HttpModule);
+
+    init! {
+        let db: DbProvider = DbModule;
+        let http: HttpProvider = HttpModule;
+    }
+
+    let repo: Repo = db.provide();
+    let port: u16 = http.provide();
+    assert_eq!(repo.0.0, 5);
+    assert_eq!(port, 8080);
+}
+
+#[test]
+fn init_block_with_three_module_chain_should_work() {
+    // Single declaration with three modules forming a dependency chain:
+    // BaseModule exports i32 → MiddleModule uses i32 to export u64 → TopModule uses u64 to export String
+
+    #[injectable]
+    #[module]
+    #[export(i32, 100)]
+    struct BaseModule;
+
+    #[injectable]
+    #[module]
+    #[export(u64, |x: i32| x as u64 * 3)]
+    struct MiddleModule;
+
+    #[injectable]
+    #[module]
+    #[export(String, |x: u64| format!("final={}", x))]
+    struct TopModule;
+
+    #[injectable]
+    #[provider]
+    struct FullProvider(
+        #[import] BaseModule,
+        #[import] MiddleModule,
+        #[import] TopModule,
+    );
+
+    init! {
+        let provider: FullProvider = BaseModule, MiddleModule, TopModule;
+    }
+
+    let i: i32 = provider.provide();
+    let u: u64 = provider.provide();
+    let s: String = provider.provide();
+    assert_eq!(i, 100);
+    assert_eq!(u, 300);
+    assert_eq!(s, "final=300");
+}
+
+#[test]
+fn init_block_with_field_exports_and_three_modules_should_work() {
+    // Three modules using field-level exports (references) in a chain.
+
+    #[derive(Debug, PartialEq)]
+    #[injectable]
+    struct Config(#[inject(7)] i32);
+
+    #[injectable]
+    #[module]
+    struct ConfigModule {
+        #[export]
+        cfg: Config,
+    }
+
+    #[derive(Debug, PartialEq)]
+    #[injectable]
+    struct Cache<'a>(#[inject(99)] i32, &'a Config);
+
+    #[injectable]
+    #[module]
+    struct CacheModule<'a> {
+        #[export]
+        cache: Cache<'a>,
+    }
+
+    #[derive(Debug, PartialEq)]
+    #[injectable]
+    struct Handler<'a>(&'a Config, &'a Cache<'a>);
+
+    #[injectable]
+    #[provider]
+    struct AppProvider<'a>(#[import] ConfigModule, #[import] CacheModule<'a>);
+
+    init! {
+        let provider: AppProvider<'_> = ConfigModule, CacheModule;
+    }
+
+    let cfg: &Config = provider.provide();
+    let cache: &Cache = provider.provide();
+    let handler: Handler = provider.provide();
+    assert_eq!(cfg.0, 7);
+    assert_eq!(cache.0, 99);
+    assert_eq!(handler.0.0, 7);
+    assert_eq!(handler.1.0, 99);
+}
+
+#[test]
+fn init_block_paren_syntax_should_still_work() {
+    // The old paren syntax `init!(let name = ...)` should still work
+    #[injectable]
+    #[module]
+    #[export(i32, 77)]
+    struct ParenModule;
+
+    #[injectable]
+    #[provider]
+    struct Provider(#[import] ParenModule);
+
+    init!(let provider: Provider = ParenModule);
+
+    let value: i32 = provider.provide();
+    assert_eq!(value, 77);
+}


### PR DESCRIPTION
Closes https://github.com/nicolascotton/nject/issues/53

A new `init!` proc macro that automates the creation of intermediate providers. It supports two forms:

### Expression form

For modules with struct-level `#[export]` (owned values):

```rust
#[injectable]
#[provider]
struct AppProvider(#[import] ConfigModule, #[import] FormatModule);

let provider: AppProvider = init!(ConfigModule, FormatModule);
```

### Block form

For modules with field-level `#[export]` (references) or cross-module borrowing.
Supports multiple declarations, like `lazy_static!`:

```rust
init! {
    let provider: AppProvider<'_> = ConfigModule, ServiceModule;
    let other: OtherProvider = SomeModule;
}
```

Also supports `mut`:

```rust
init! {
    let mut provider: AppProvider = ConfigModule, FormatModule;
}
```

The paren syntax `init!(let provider = M1, M2)` also works for single declarations.

## How it works

`init!(ConfigModule, FormatModule)` expands to:

```rust
{
    // 1. Empty init provider — can provide any #[injectable] type
    #[nject::provider]
    struct __NjectInit_expr;

    // 2. Step 0 — imports ConfigModule, gaining its exports
    #[nject::injectable]
    #[nject::provider]
    struct __NjectInitStep_expr_0(#[import] ConfigModule);

    // 3. Chain: init -> step0 -> target
    let __nject_init_expr = __NjectInit_expr;
    let __nject_expr_s0 = __nject_init_expr.provide::<__NjectInitStep_expr_0>();
    __nject_expr_s0.provide() // <- type inferred from context
}
```

The block form `init! { let provider = ConfigModule, FormatModule; }` expands the same structs and let-bindings **into the enclosing scope** (not a block), so intermediate providers stay alive and the final provider can borrow from them:

```rust
// Structs and bindings live in the enclosing scope:
struct __NjectInit_provider;
struct __NjectInitStep_provider_0(#[import] ConfigModule);

let __nject_init_provider = __NjectInit_provider;
let __nject_provider_s0 = __nject_init_provider.provide::<__NjectInitStep_provider_0>();
let provider: AppProvider<'_> = __nject_provider_s0.provide();
// provider can borrow from __nject_provider_s0 — both live in the same scope
```