### PR TITLE
feat: Allow init macro to initialize a provider without modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ fn main() {
 ```
 ### Use modules to export internal shared dependencies
 ```rust
-use nject::{injectable, provider};
+use nject::{init, injectable, provider};
 
 mod sub {
     use nject::{injectable, module};
@@ -281,10 +281,7 @@ struct Provider {
 }
 
 fn main() {
-    #[provider]
-    struct InitProvider;
-
-    let provider = InitProvider.provide::<Provider>();
+    let provider: Provider = init!();
     let _facade = provider.provide::<sub::Facade>();
 }
 ```
@@ -294,7 +291,7 @@ fn main() {
 
 ### Use modules to export public dependencies
 ```rust
-use nject::{injectable, provider};
+use nject::{init, injectable, provider};
 
 mod sub {
     use nject::{injectable, module};
@@ -343,10 +340,7 @@ struct Provider {
 }
 
 fn main() {
-    #[provider]
-    struct InitProvider;
-
-    let provider = InitProvider.provide::<Provider>();
+    let provider: Provider = init!();
     let _facade = provider.provide::<sub::Facade>();
 }
 ```
@@ -357,7 +351,7 @@ fn main() {
 
 ### Use modules to export multiple implementations for a public type
 ```rust
-use nject::{injectable, provider};
+use nject::{init, injectable, provider};
 
 mod one {
     use nject::{injectable, module};
@@ -417,10 +411,7 @@ struct Provider {
 }
 
 fn main() {
-    #[provider]
-    struct InitProvider;
-
-    let provider = InitProvider.provide::<Provider>();
+    let provider: Provider = init!();
     let greetings = provider.iter::<&dyn Greeter>()
         .map(|g| g.greet())
         .collect::<Vec<_>>();
@@ -435,7 +426,7 @@ Same as [module public exports](#limitations-1)
 
 ### Use scopes to scope dependencies
 ```rust
-use nject::{injectable, module, provider};
+use nject::{init, injectable, module, provider};
 
 #[injectable]
 struct ModuleDep;
@@ -469,10 +460,7 @@ struct ScopeFacade<'a> {
 struct Provider(#[provide] RootDep);
 
 fn main() {
-    #[provider]
-    struct InitProvider;
-
-    let provider = InitProvider.provide::<Provider>();
+    let provider: Provider = init!();
     let scope = provider.scope();
     let scope_facade = scope.provide::<ScopeFacade>();
 

--- a/examples/axum/src/main.rs
+++ b/examples/axum/src/main.rs
@@ -7,7 +7,7 @@ use axum::{
 };
 use axum_example::CreateUser;
 use axum_example::UserService;
-use nject::{injectable, provider};
+use nject::{init, injectable, provider};
 
 #[provider]
 #[injectable]
@@ -15,10 +15,7 @@ pub struct Provider(#[import] axum_example::Module);
 
 #[tokio::main]
 async fn main() {
-    #[provider]
-    struct InitProvider;
-
-    let provider: &'static Provider = Box::leak(Box::new(InitProvider.provide()));
+    let provider: &'static Provider = Box::leak(Box::new(init!()));
     let app = Router::new()
         .route("/api/users", post(create_user))
         .route("/api/users/{id}", get(get_user))

--- a/examples/benchmark/src/scope.rs
+++ b/examples/benchmark/src/scope.rs
@@ -1,5 +1,5 @@
 use super::*;
-use nject::{injectable, provider};
+use nject::{init, injectable, provider};
 use test::Bencher;
 
 #[bench]
@@ -60,10 +60,7 @@ fn by_ref_from_root(b: &mut Bencher) {
         #[provide] Dep10,
     );
 
-    #[provider]
-    struct InitProvider;
-
-    let root = InitProvider.provide::<Root>();
+    let root: Root = init!();
     b.iter(move || {
         for _ in 0..ITERATION_COUNT {
             let scope = root.scope();

--- a/examples/leptos/src/counter/store.rs
+++ b/examples/leptos/src/counter/store.rs
@@ -1,26 +1,26 @@
+use crate::Provider;
 use leptos::prelude::*;
 use nject::inject;
-use crate::Provider;
 
 #[inject({ 
 	let (read, write) = signal(0);
 	Self { read, write }
 })]
 pub struct CounterStore {
-	read: ReadSignal<i32>,
-	write: WriteSignal<i32>
+    read: ReadSignal<i32>,
+    write: WriteSignal<i32>,
 }
 
 impl CounterStore {
-	pub fn map<T>(&self, map: impl FnOnce(&i32) -> T) -> T {
-		self.read.with(map)
-	}
+    pub fn map<T>(&self, map: impl FnOnce(&i32) -> T) -> T {
+        self.read.with(map)
+    }
 
-	pub fn update(&self, update: impl FnOnce(&mut i32) ) {
-		self.write.update(update);
-	}
+    pub fn update(&self, update: impl FnOnce(&mut i32)) {
+        self.write.update(update);
+    }
 }
 
 pub fn counter_store<'a>() -> &'a CounterStore {
-	Provider::inject::<&CounterStore>()
+    Provider::inject::<&CounterStore>()
 }

--- a/examples/leptos/src/lib.rs
+++ b/examples/leptos/src/lib.rs
@@ -1,6 +1,6 @@
 mod counter;
 pub use counter::*;
-use nject::{injectable, provider};
+use nject::{init, injectable, provider};
 
 const PROVIDER: *mut Provider = std::ptr::null_mut();
 
@@ -14,10 +14,7 @@ pub struct Provider {
 impl Provider {
     /// Initialize the Provider in static const PROVIDER.
     pub fn init() {
-        #[provider]
-        struct InitProvider;
-
-        let prov = InitProvider.provide::<Provider>();
+        let prov: Provider = init!();
         unsafe { std::ptr::swap(PROVIDER, Box::leak(Box::from(prov))) };
     }
 

--- a/examples/pubsub/src/main.rs
+++ b/examples/pubsub/src/main.rs
@@ -1,4 +1,4 @@
-use nject::{Iterable, injectable, provider};
+use nject::{Iterable, init, injectable, provider};
 use pubsub::{FirstMessage, SecondMessage, Subscriber};
 
 #[injectable]
@@ -21,10 +21,7 @@ impl Publisher {
 }
 
 fn main() {
-    #[provider]
-    struct InitProvider;
-
-    let publisher = InitProvider.provide::<Publisher>();
+    let publisher: Publisher = init!();
 
     publisher
         .publish(&FirstMessage)

--- a/nject-macro/Cargo.toml
+++ b/nject-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nject-macro"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 description = "Zero cost dependency injection macros"
 rust-version = "1.85"

--- a/nject-macro/README.md
+++ b/nject-macro/README.md
@@ -228,7 +228,7 @@ fn main() {
 ```
 ### Use modules to export internal shared dependencies
 ```rust
-use nject::{injectable, provider};
+use nject::{init, injectable, provider};
 
 mod sub {
     use nject::{injectable, module};
@@ -281,10 +281,7 @@ struct Provider {
 }
 
 fn main() {
-    #[provider]
-    struct InitProvider;
-
-    let provider = InitProvider.provide::<Provider>();
+    let provider: Provider = init!();
     let _facade = provider.provide::<sub::Facade>();
 }
 ```
@@ -294,7 +291,7 @@ fn main() {
 
 ### Use modules to export public dependencies
 ```rust
-use nject::{injectable, provider};
+use nject::{init, injectable, provider};
 
 mod sub {
     use nject::{injectable, module};
@@ -343,10 +340,7 @@ struct Provider {
 }
 
 fn main() {
-    #[provider]
-    struct InitProvider;
-
-    let provider = InitProvider.provide::<Provider>();
+    let provider: Provider = init!();
     let _facade = provider.provide::<sub::Facade>();
 }
 ```
@@ -357,7 +351,7 @@ fn main() {
 
 ### Use modules to export multiple implementations for a public type
 ```rust
-use nject::{injectable, provider};
+use nject::{init, injectable, provider};
 
 mod one {
     use nject::{injectable, module};
@@ -417,10 +411,7 @@ struct Provider {
 }
 
 fn main() {
-    #[provider]
-    struct InitProvider;
-
-    let provider = InitProvider.provide::<Provider>();
+    let provider: Provider = init!();
     let greetings = provider.iter::<&dyn Greeter>()
         .map(|g| g.greet())
         .collect::<Vec<_>>();
@@ -435,7 +426,7 @@ Same as [module public exports](#limitations-1)
 
 ### Use scopes to scope dependencies
 ```rust
-use nject::{injectable, module, provider};
+use nject::{init, injectable, module, provider};
 
 #[injectable]
 struct ModuleDep;
@@ -469,10 +460,7 @@ struct ScopeFacade<'a> {
 struct Provider(#[provide] RootDep);
 
 fn main() {
-    #[provider]
-    struct InitProvider;
-
-    let provider = InitProvider.provide::<Provider>();
+    let provider: Provider = init!();
     let scope = provider.scope();
     let scope_facade = scope.provide::<ScopeFacade>();
 

--- a/nject-macro/src/finalize.rs
+++ b/nject-macro/src/finalize.rs
@@ -3,9 +3,8 @@ use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 use syn::{
-    braced,
+    Ident, Token, braced,
     parse::{Parse, ParseStream},
-    Ident, Token,
 };
 
 fn parse_named_bracketed_tokens(input: ParseStream, name: &str) -> syn::Result<TokenStream2> {

--- a/nject-macro/src/init.rs
+++ b/nject-macro/src/init.rs
@@ -1,4 +1,5 @@
 use proc_macro::TokenStream;
+use proc_macro2::Span;
 use quote::{format_ident, quote};
 use syn::{
     GenericArgument, Ident, Lifetime, Token, Type,
@@ -156,9 +157,13 @@ fn gen_chain(
     for i in 0..step_count {
         let step_ident = format_ident!("__NjectInitStep_{}_{}", name_prefix, i);
         let step_modules = &modules[0..=i];
+        let chain_lifetime = Lifetime::new("'nject_init", Span::call_site());
 
         // Collect unique lifetimes from all module types in this step
         let mut lifetimes = Vec::new();
+        if i > 0 {
+            lifetimes.push(chain_lifetime.clone());
+        }
         for m in step_modules {
             collect_lifetimes_from_type(m, &mut lifetimes);
         }
@@ -169,8 +174,14 @@ fn gen_chain(
             quote! { <#(#lifetimes),*> }
         };
 
-        let import_fields = step_modules.iter().map(|m| {
-            quote! { #[import] #m }
+        let import_fields = step_modules.iter().enumerate().map(|(module_index, m)| {
+            let ty = if module_index < i {
+                quote! { &#chain_lifetime #m }
+            } else {
+                quote! { #m }
+            };
+
+            quote! { #[import] #[provide] #ty }
         });
 
         struct_defs.push(quote! {
@@ -263,7 +274,8 @@ fn handle_init_block(declarations: &[LetDecl]) -> syn::Result<TokenStream> {
                 let #mutability #ident #ty_annotation = #init_ident.provide();
             });
         } else {
-            let (struct_defs, let_bindings, last_var) = gen_chain(&decl.modules, &name_prefix, false);
+            let (struct_defs, let_bindings, last_var) =
+                gen_chain(&decl.modules, &name_prefix, false);
             all_tokens.push(quote! {
                 #(#struct_defs)*
                 #(#let_bindings)*

--- a/nject-macro/src/init.rs
+++ b/nject-macro/src/init.rs
@@ -7,11 +7,12 @@ use syn::{
 };
 
 /// Two forms:
-/// - Expression: `init!(M1, M2, M3)` -> block expression (owned modules only)
+/// - Expression: `init!(M1, M2, M3)` or `init!()` -> block expression (owned modules only)
 /// - Block:
 ///   ```ignore
 ///   init! {
 ///       let [mut] name [: Type] = M1, M2;
+///       let [mut] name [: Type];
 ///       let [mut] name [: Type] = M3;
 ///   }
 ///   ```
@@ -65,13 +66,24 @@ impl Parse for LetDecl {
         } else {
             None
         };
-        input.parse::<Token![=]>()?;
-        let modules = Punctuated::<Type, Token![,]>::parse_separated_nonempty(input)?;
+        let mut modules = Vec::new();
+        if input.peek(Token![=]) {
+            input.parse::<Token![=]>()?;
+            while !input.is_empty() && !input.peek(Token![;]) {
+                modules.push(input.parse::<Type>()?);
+
+                if input.peek(Token![,]) {
+                    input.parse::<Token![,]>()?;
+                } else {
+                    break;
+                }
+            }
+        }
         Ok(LetDecl {
             is_mut,
             ident,
             ty,
-            modules: modules.into_iter().collect(),
+            modules,
         })
     }
 }
@@ -177,15 +189,7 @@ pub(crate) fn handle_init(item: TokenStream) -> syn::Result<TokenStream> {
     let input = syn::parse::<InitInput>(item)?;
 
     match input {
-        InitInput::Expr { modules } => {
-            if modules.is_empty() {
-                return Err(syn::Error::new(
-                    proc_macro2::Span::call_site(),
-                    "init! requires at least one module type",
-                ));
-            }
-            handle_init_expr(&modules)
-        }
+        InitInput::Expr { modules } => handle_init_expr(&modules),
         InitInput::Block { declarations } => {
             if declarations.is_empty() {
                 return Err(syn::Error::new(
@@ -198,9 +202,9 @@ pub(crate) fn handle_init(item: TokenStream) -> syn::Result<TokenStream> {
     }
 }
 
-/// Expression form: `init!(M1, M2)` -> block expression
+/// Expression form: `init!(M1, M2)` or `init!()` -> block expression
 fn handle_init_expr(modules: &[Type]) -> syn::Result<TokenStream> {
-    if modules.len() == 1 {
+    if modules.len() <= 1 {
         let output = quote! {
             {
                 #[nject::provider]
@@ -229,13 +233,6 @@ fn handle_init_block(declarations: &[LetDecl]) -> syn::Result<TokenStream> {
     let mut all_tokens = Vec::new();
 
     for decl in declarations {
-        if decl.modules.is_empty() {
-            return Err(syn::Error::new(
-                proc_macro2::Span::call_site(),
-                "each let declaration requires at least one module type",
-            ));
-        }
-
         let mutability = if decl.is_mut {
             quote! { mut }
         } else {
@@ -250,7 +247,7 @@ fn handle_init_block(declarations: &[LetDecl]) -> syn::Result<TokenStream> {
         let ident = &decl.ident;
         let name_prefix = ident.to_string();
 
-        if decl.modules.len() == 1 {
+        if decl.modules.len() <= 1 {
             let init_ident = format_ident!("__NjectInit_{}", name_prefix);
             all_tokens.push(quote! {
                 #[nject::provider]

--- a/nject-macro/src/init.rs
+++ b/nject-macro/src/init.rs
@@ -126,6 +126,7 @@ fn collect_lifetimes_from_type(ty: &Type, lifetimes: &mut Vec<Lifetime>) {
 fn gen_chain(
     modules: &[Type],
     name_prefix: &str,
+    include_final_module: bool,
 ) -> (
     Vec<proc_macro2::TokenStream>,
     Vec<proc_macro2::TokenStream>,
@@ -146,7 +147,13 @@ fn gen_chain(
 
     let mut last_var = init_var.clone();
 
-    for i in 0..modules.len() - 1 {
+    let step_count = if include_final_module {
+        modules.len()
+    } else {
+        modules.len().saturating_sub(1)
+    };
+
+    for i in 0..step_count {
         let step_ident = format_ident!("__NjectInitStep_{}_{}", name_prefix, i);
         let step_modules = &modules[0..=i];
 
@@ -204,7 +211,7 @@ pub(crate) fn handle_init(item: TokenStream) -> syn::Result<TokenStream> {
 
 /// Expression form: `init!(M1, M2)` or `init!()` -> block expression
 fn handle_init_expr(modules: &[Type]) -> syn::Result<TokenStream> {
-    if modules.len() <= 1 {
+    if modules.is_empty() {
         let output = quote! {
             {
                 #[nject::provider]
@@ -215,7 +222,7 @@ fn handle_init_expr(modules: &[Type]) -> syn::Result<TokenStream> {
         return Ok(output.into());
     }
 
-    let (struct_defs, let_bindings, last_var) = gen_chain(modules, "expr");
+    let (struct_defs, let_bindings, last_var) = gen_chain(modules, "expr", true);
 
     let output = quote! {
         {
@@ -247,7 +254,7 @@ fn handle_init_block(declarations: &[LetDecl]) -> syn::Result<TokenStream> {
         let ident = &decl.ident;
         let name_prefix = ident.to_string();
 
-        if decl.modules.len() <= 1 {
+        if decl.modules.is_empty() {
             let init_ident = format_ident!("__NjectInit_{}", name_prefix);
             all_tokens.push(quote! {
                 #[nject::provider]
@@ -256,7 +263,7 @@ fn handle_init_block(declarations: &[LetDecl]) -> syn::Result<TokenStream> {
                 let #mutability #ident #ty_annotation = #init_ident.provide();
             });
         } else {
-            let (struct_defs, let_bindings, last_var) = gen_chain(&decl.modules, &name_prefix);
+            let (struct_defs, let_bindings, last_var) = gen_chain(&decl.modules, &name_prefix, false);
             all_tokens.push(quote! {
                 #(#struct_defs)*
                 #(#let_bindings)*

--- a/nject-macro/src/lib.rs
+++ b/nject-macro/src/lib.rs
@@ -114,7 +114,7 @@ pub fn provider(_attr: TokenStream, item: TokenStream) -> TokenStream {
 
 /// Declare a module to export internal types.
 /// ```rust
-/// use nject::{injectable, provider};
+/// use nject::{init, injectable, provider};
 ///
 /// mod sub {
 ///     use nject::{injectable, module};
@@ -150,11 +150,8 @@ pub fn provider(_attr: TokenStream, item: TokenStream) -> TokenStream {
 ///     sub_mod: crate::sub::Module,
 /// }
 ///
-/// #[provider]
-/// struct InitProvider;
-///
 /// fn main() {
-///     let provider = InitProvider.provide::<Provider>();
+///     let provider: Provider = init!();
 ///     let facade = provider.provide::<sub::Facade>();
 /// }
 /// ```
@@ -194,6 +191,18 @@ pub fn module(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// assert_eq!(greeting, "value: 42");
 /// ```
 ///
+/// Providers that do not import modules can be initialized with an empty module list.
+///
+/// ```rust
+/// use nject::{init, injectable, provider};
+///
+/// #[injectable]
+/// #[provider]
+/// struct AppProvider;
+///
+/// let provider: AppProvider = init!();
+/// ```
+///
 /// # Block form
 ///
 /// Expands `let` declarations into the enclosing scope, keeping intermediate providers alive.
@@ -225,6 +234,20 @@ pub fn module(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// }
 /// let consumer: Consumer = provider.provide();
 /// assert_eq!(consumer.0.0, 42);
+/// ```
+///
+/// In block form, omit `=` and the module list for moduleless providers.
+///
+/// ```rust
+/// use nject::{init, injectable, provider};
+///
+/// #[injectable]
+/// #[provider]
+/// struct AppProvider;
+///
+/// init! {
+///     let provider: AppProvider;
+/// }
 /// ```
 #[proc_macro]
 pub fn init(item: TokenStream) -> TokenStream {

--- a/nject/Cargo.toml
+++ b/nject/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nject"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 description = "Zero cost dependency injection module"
 rust-version = "1.85"
@@ -13,7 +13,7 @@ repository = "https://github.com/nicolascotton/nject"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nject-macro = { path = "../nject-macro", version = "0.5.0", optional = true }
+nject-macro = { path = "../nject-macro", version = "0.5.1", optional = true }
 
 [features]
 default = ["macro"]

--- a/nject/README.md
+++ b/nject/README.md
@@ -228,7 +228,7 @@ fn main() {
 ```
 ### Use modules to export internal shared dependencies
 ```rust
-use nject::{injectable, provider};
+use nject::{init, injectable, provider};
 
 mod sub {
     use nject::{injectable, module};
@@ -281,10 +281,7 @@ struct Provider {
 }
 
 fn main() {
-    #[provider]
-    struct InitProvider;
-
-    let provider = InitProvider.provide::<Provider>();
+    let provider: Provider = init!();
     let _facade = provider.provide::<sub::Facade>();
 }
 ```
@@ -294,7 +291,7 @@ fn main() {
 
 ### Use modules to export public dependencies
 ```rust
-use nject::{injectable, provider};
+use nject::{init, injectable, provider};
 
 mod sub {
     use nject::{injectable, module};
@@ -343,10 +340,7 @@ struct Provider {
 }
 
 fn main() {
-    #[provider]
-    struct InitProvider;
-
-    let provider = InitProvider.provide::<Provider>();
+    let provider: Provider = init!();
     let _facade = provider.provide::<sub::Facade>();
 }
 ```
@@ -357,7 +351,7 @@ fn main() {
 
 ### Use modules to export multiple implementations for a public type
 ```rust
-use nject::{injectable, provider};
+use nject::{init, injectable, provider};
 
 mod one {
     use nject::{injectable, module};
@@ -417,10 +411,7 @@ struct Provider {
 }
 
 fn main() {
-    #[provider]
-    struct InitProvider;
-
-    let provider = InitProvider.provide::<Provider>();
+    let provider: Provider = init!();
     let greetings = provider.iter::<&dyn Greeter>()
         .map(|g| g.greet())
         .collect::<Vec<_>>();
@@ -435,7 +426,7 @@ Same as [module public exports](#limitations-1)
 
 ### Use scopes to scope dependencies
 ```rust
-use nject::{injectable, module, provider};
+use nject::{init, injectable, module, provider};
 
 #[injectable]
 struct ModuleDep;
@@ -469,10 +460,7 @@ struct ScopeFacade<'a> {
 struct Provider(#[provide] RootDep);
 
 fn main() {
-    #[provider]
-    struct InitProvider;
-
-    let provider = InitProvider.provide::<Provider>();
+    let provider: Provider = init!();
     let scope = provider.scope();
     let scope_facade = scope.provide::<ScopeFacade>();
 

--- a/nject/src/lib.rs
+++ b/nject/src/lib.rs
@@ -4,8 +4,8 @@
 
 #[cfg(feature = "macro")]
 pub use nject_macro::{
-    InjectableHelperAttr, ModuleHelperAttr, ProviderHelperAttr, ScopeHelperAttr,
-    __nject_finalize_imports, init, inject, injectable, module, provider,
+    __nject_finalize_imports, InjectableHelperAttr, ModuleHelperAttr, ProviderHelperAttr,
+    ScopeHelperAttr, init, inject, injectable, module, provider,
 };
 
 /// Provide a value for a specified type. Should be used with the `provide` macro for a better experience.
@@ -62,7 +62,7 @@ pub trait Injectable<'prov, Injecty, Provider> {
 
 /// Import exportations made from a module. Should be used with the `import` macro for a better experience.
 /// ```rust
-/// use nject::{injectable, provider};
+/// use nject::{init, injectable, provider};
 ///
 /// mod sub {
 ///     use nject::{injectable, module};
@@ -87,11 +87,8 @@ pub trait Injectable<'prov, Injecty, Provider> {
 /// #[provider]
 /// struct Provider(#[import] crate::sub::SubModule);
 ///
-/// #[provider]
-/// struct InitProvider;
-///
 /// fn main() {
-///     let provider = InitProvider.provide::<Provider>();
+///     let provider: Provider = init!();
 ///     let facade = provider.provide::<sub::Facade>();
 /// }
 /// ```

--- a/nject/src/lib.rs
+++ b/nject/src/lib.rs
@@ -102,10 +102,34 @@ pub trait RefInjectable<'prov, Value, Provider> {
     fn inject(&'prov self, provider: &'prov Provider) -> Value;
 }
 
+impl<'prov, 'module, Value, Provider, Module> RefInjectable<'prov, Value, Provider>
+    for &'module Module
+where
+    'module: 'prov,
+    Module: RefInjectable<'prov, Value, Provider>,
+{
+    #[inline]
+    fn inject(&'prov self, provider: &'prov Provider) -> Value {
+        (**self).inject(provider)
+    }
+}
+
 /// For internal purposes only. Should not be used.
 #[doc(hidden)]
 pub trait RefIterable<'prov, Value, Provider> {
     fn inject(&'prov self, provider: &'prov Provider, index: usize) -> Value;
+}
+
+impl<'prov, 'module, Value, Provider, Module> RefIterable<'prov, Value, Provider>
+    for &'module Module
+where
+    'module: 'prov,
+    Module: RefIterable<'prov, Value, Provider>,
+{
+    #[inline]
+    fn inject(&'prov self, provider: &'prov Provider, index: usize) -> Value {
+        (**self).inject(provider, index)
+    }
 }
 
 /// For internal purposes only. Should not be used.

--- a/nject/tests/init.rs
+++ b/nject/tests/init.rs
@@ -29,7 +29,7 @@ fn init_expr_with_single_module_should_provide_target() {
 
     #[injectable]
     #[provider]
-    struct Provider(#[import] FooModule);
+    struct Provider(#[provide(i32, |x| *x)] i32);
 
     let provider: Provider = init!(FooModule);
 
@@ -51,7 +51,7 @@ fn init_expr_with_two_modules_should_chain_dependencies() {
 
     #[injectable]
     #[provider]
-    struct AppProvider(#[import] ExprTwoConfigModule, #[import] ExprTwoFormatModule);
+    struct AppProvider(#[provide(String, |x| x.to_owned())] String);
 
     let provider: AppProvider = init!(ExprTwoConfigModule, ExprTwoFormatModule);
 

--- a/nject/tests/init.rs
+++ b/nject/tests/init.rs
@@ -60,6 +60,46 @@ fn init_expr_with_two_modules_should_chain_dependencies() {
 }
 
 #[test]
+fn init_expr_with_two_modules_should_reference_previous_module() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    static INIT_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+    fn next_init_id() -> usize {
+        INIT_COUNT.fetch_add(1, Ordering::SeqCst)
+    }
+
+    #[derive(Debug, PartialEq)]
+    #[injectable]
+    struct Unique(#[inject(next_init_id())] usize);
+
+    struct StateId(usize);
+
+    #[injectable]
+    #[module]
+    struct StatefulModule {
+        #[export(StateId, |value| StateId(value.0))]
+        #[export]
+        value: Unique,
+    }
+
+    #[injectable]
+    #[module]
+    #[export(String, |value: StateId| format!("id={}", value.0))]
+    struct UsesStatefulModule;
+
+    #[injectable]
+    #[provider]
+    struct Provider(#[provide(String, |x| x.to_owned())] String);
+
+    let provider: Provider = init!(StatefulModule, UsesStatefulModule);
+
+    let value: String = provider.provide();
+    assert_eq!(value, "id=0");
+    assert_eq!(INIT_COUNT.load(Ordering::SeqCst), 1);
+}
+
+#[test]
 fn init_expr_with_three_modules_should_chain_all_dependencies() {
     #[injectable]
     #[module]

--- a/nject/tests/init.rs
+++ b/nject/tests/init.rs
@@ -1,6 +1,26 @@
 use nject::{init, injectable, module, provider};
 
 #[test]
+fn init_expr_without_modules_should_provide_target() {
+    #[derive(Debug, PartialEq)]
+    #[injectable]
+    struct Dependency(#[inject(42)] i32);
+
+    #[derive(Debug, PartialEq)]
+    #[injectable]
+    struct Service(Dependency);
+
+    #[injectable]
+    #[provider]
+    struct Provider;
+
+    let provider: Provider = init!();
+
+    let service: Service = provider.provide();
+    assert_eq!(service.0.0, 42);
+}
+
+#[test]
 fn init_expr_with_single_module_should_provide_target() {
     #[injectable]
     #[module]
@@ -64,7 +84,11 @@ fn init_expr_with_three_modules_should_chain_all_dependencies() {
         #[import] ExprThreeTopModule,
     );
 
-    let provider: Provider = init!(ExprThreeBaseModule, ExprThreeMiddleModule, ExprThreeTopModule);
+    let provider: Provider = init!(
+        ExprThreeBaseModule,
+        ExprThreeMiddleModule,
+        ExprThreeTopModule
+    );
 
     let result: String = provider.provide();
     assert_eq!(result, "result: 101");
@@ -94,7 +118,106 @@ fn init_expr_with_independent_modules_should_work() {
     assert_eq!(b, 20);
 }
 
-// ── Block form: init! { let name = M1, M2; } ───────────────────────
+#[test]
+fn init_block_without_modules_should_provide_target() {
+    #[derive(Debug, PartialEq)]
+    #[injectable]
+    struct Dependency(#[inject(99)] i32);
+
+    #[derive(Debug, PartialEq)]
+    #[injectable]
+    struct Service(Dependency);
+
+    #[injectable]
+    #[provider]
+    struct Provider;
+
+    init! {
+        let provider: Provider;
+    }
+
+    let service: Service = provider.provide();
+    assert_eq!(service.0.0, 99);
+}
+
+#[test]
+fn init_block_without_modules_and_without_type_annotation_should_infer_type() {
+    #[derive(Debug, PartialEq)]
+    #[injectable]
+    struct Dependency(#[inject(55)] i32);
+
+    #[derive(Debug, PartialEq)]
+    #[injectable]
+    struct Service(Dependency);
+
+    #[injectable]
+    #[provider]
+    struct Provider;
+
+    init! {
+        let provider;
+    }
+
+    let provider: Provider = provider;
+    let service: Service = provider.provide();
+    assert_eq!(service.0.0, 55);
+}
+
+#[test]
+fn init_block_with_mixed_module_and_moduleless_declarations_should_work() {
+    #[derive(Debug, PartialEq)]
+    #[injectable]
+    struct SimpleDependency(#[inject(7)] i32);
+
+    #[derive(Debug, PartialEq)]
+    #[injectable]
+    struct SimpleService(SimpleDependency);
+
+    #[injectable]
+    #[provider]
+    struct SimpleProvider;
+
+    #[injectable]
+    #[module]
+    #[export(i32, 10)]
+    struct ModuleProviderModule;
+
+    #[injectable]
+    #[provider]
+    struct ModuleProvider(#[import] ModuleProviderModule);
+
+    init! {
+        let simple: SimpleProvider;
+        let with_module: ModuleProvider = ModuleProviderModule;
+    }
+
+    let service: SimpleService = simple.provide();
+    let value: i32 = with_module.provide();
+    assert_eq!(service.0.0, 7);
+    assert_eq!(value, 10);
+}
+
+#[test]
+fn init_block_mut_without_modules_should_allow_mutation() {
+    #[derive(Debug, PartialEq)]
+    #[injectable]
+    struct Service(#[inject(0)] i32);
+
+    #[injectable]
+    #[provider]
+    struct Provider;
+
+    init! {
+        let mut provider: Provider;
+    }
+    init! {
+        let provider2: Provider;
+    }
+    provider = provider2;
+
+    let value: Service = provider.provide();
+    assert_eq!(value.0, 0);
+}
 
 #[test]
 fn init_block_with_single_module_should_provide_target() {
@@ -247,7 +370,10 @@ fn init_block_with_cross_module_borrowing_should_work() {
 
     #[injectable]
     #[provider]
-    struct AppProvider<'a>(#[import] CrossConfigModule, #[import] CrossServiceModule<'a>);
+    struct AppProvider<'a>(
+        #[import] CrossConfigModule,
+        #[import] CrossServiceModule<'a>,
+    );
 
     init! {
         let provider: AppProvider<'_> = CrossConfigModule, CrossServiceModule;
@@ -441,7 +567,10 @@ fn init_block_with_field_exports_and_three_modules_should_work() {
 
     #[injectable]
     #[provider]
-    struct AppProvider<'a>(#[import] FieldThreeConfigModule, #[import] FieldThreeCacheModule<'a>);
+    struct AppProvider<'a>(
+        #[import] FieldThreeConfigModule,
+        #[import] FieldThreeCacheModule<'a>,
+    );
 
     init! {
         let provider: AppProvider<'_> = FieldThreeConfigModule, FieldThreeCacheModule;

--- a/nject/tests/iterable.rs
+++ b/nject/tests/iterable.rs
@@ -1,8 +1,5 @@
-use nject::{injectable, module, provider};
+use nject::{init, injectable, module, provider};
 use std::vec;
-
-#[provider]
-struct InitProvider;
 
 #[test]
 fn iter_with_multiple_exports_for_a_type_from_different_modules_should_return_iterable_of_exports()
@@ -22,7 +19,7 @@ fn iter_with_multiple_exports_for_a_type_from_different_modules_should_return_it
         #[import] IterDiffFirstModuleStr,
         #[import] IterDiffLastModuleStr,
     );
-    let provider = InitProvider.provide::<Provider>();
+    let provider: Provider = init!();
     // When
     let values = provider.iter::<&str>().collect::<Vec<_>>();
     // Then
@@ -47,7 +44,7 @@ fn provide_with_multiple_exports_for_a_type_from_different_modules_should_return
         #[import] ProvDiffFirstModuleStr,
         #[import] ProvDiffLastModuleStr,
     );
-    let provider = InitProvider.provide::<Provider>();
+    let provider: Provider = init!();
     // When
     let value = provider.provide::<&str>();
     // Then
@@ -65,7 +62,7 @@ fn iter_with_multiple_exports_for_a_type_from_same_modules_should_return_iterabl
     #[injectable]
     #[provider]
     struct Provider(#[import] IterSameModuleStr);
-    let provider = InitProvider.provide::<Provider>();
+    let provider: Provider = init!();
     // When
     let values = provider.iter::<&str>().collect::<Vec<_>>();
     // Then
@@ -83,7 +80,7 @@ fn provide_with_multiple_exports_for_a_type_from_same_modules_should_return_last
     #[injectable]
     #[provider]
     struct Provider(#[import] ProvSameModuleStr);
-    let provider = InitProvider.provide::<Provider>();
+    let provider: Provider = init!();
     // When
     let value = provider.provide::<&str>();
     // Then
@@ -129,7 +126,7 @@ fn iter_with_multiple_exports_module_imported_from_root_should_return_iterable_o
     #[scope(ScopedDep)]
     struct Root(#[import] MultiExportRootModule);
 
-    let root = InitProvider.provide::<Root>();
+    let root: Root = init!();
     let scope = root.scope();
     // When
     let values = scope.iter::<i32>().collect::<Vec<_>>();
@@ -148,7 +145,7 @@ fn iter_with_single_export_for_a_type_should_return_iterable_of_one() {
     #[injectable]
     #[provider]
     struct Provider(#[import] IterSingleExportModule);
-    let provider = InitProvider.provide::<Provider>();
+    let provider: Provider = init!();
     // When
     let values = provider.iter::<&str>().collect::<Vec<_>>();
     // Then

--- a/nject/tests/module.rs
+++ b/nject/tests/module.rs
@@ -1,9 +1,6 @@
 use crate::sub::Greeter;
-use nject::{injectable, module, provider};
+use nject::{init, injectable, module, provider};
 use std::rc::Rc;
-
-#[provider]
-struct InitProvider;
 
 #[test]
 fn provide_with_simple_module_should_export_its_members_correctly() {
@@ -11,7 +8,7 @@ fn provide_with_simple_module_should_export_its_members_correctly() {
     #[injectable]
     #[provider]
     struct Provider(#[import] crate::sub::SimpleModule);
-    let provider = InitProvider.provide::<Provider>();
+    let provider: Provider = init!();
     // When
     let facade = provider.provide::<sub::SimpleFacade>();
     // Then
@@ -24,7 +21,7 @@ fn provide_with_ref_to_module_should_export_its_members_correctly() {
     #[injectable]
     #[provider]
     struct Provider<'a>(#[import] &'a crate::sub::SimpleModule);
-    let module = InitProvider.provide::<sub::SimpleModule>();
+    let module: sub::SimpleModule = init!();
     let provider = Provider(&module);
     // When
     let facade = provider.provide::<sub::SimpleFacade>();
@@ -35,13 +32,14 @@ fn provide_with_ref_to_module_should_export_its_members_correctly() {
 #[test]
 fn provide_with_generic_module_should_export_its_members_correctly() {
     // Given
+    #[injectable]
     #[provider]
     #[provide(&'prov i32, &self.0)]
-    struct InitProvider(i32);
+    struct SeedProvider(#[inject(123)] i32);
     #[injectable]
     #[provider]
     struct Provider<'a, T>(#[import] crate::sub::GenericModule<'a, T>);
-    let init_prov = InitProvider(123);
+    let init_prov: SeedProvider = init!();
     let provider = init_prov.provide::<Provider<i32>>();
     // When
     let facade = provider.provide::<sub::GenericFacade<_>>();
@@ -55,7 +53,7 @@ fn provide_with_module_with_ref_dep_should_export_its_members_correctly() {
     #[injectable]
     #[provider]
     struct Provider<'a>(#[import] crate::sub::ModuleWithRef<'a>);
-    let provider = InitProvider.provide::<Provider>();
+    let provider: Provider = init!();
     // When
     let facade = provider.provide::<sub::SimpleRefFacade>();
     // Then
@@ -68,7 +66,7 @@ fn provide_with_module_with_dyn_dep_should_export_its_members_correctly() {
     #[injectable]
     #[provider]
     struct Provider(#[import] crate::sub::DynDepModule);
-    let provider = InitProvider.provide::<Provider>();
+    let provider: Provider = init!();
     // When
     let dep = provider.provide::<&dyn sub::Greeter>();
     // Then
@@ -87,7 +85,7 @@ fn provide_with_module_with_external_type_export_with_simple_factory_should_prov
     #[injectable]
     #[provider]
     struct Provider(#[import] crate::TestModule1);
-    let provider = InitProvider.provide::<Provider>();
+    let provider: Provider = init!();
     // When
     let dep = provider.provide::<Rc<i32>>();
     // Then
@@ -106,7 +104,7 @@ fn provide_with_module_with_external_type_export_with_complex_factory_should_pro
     #[provider]
     #[provide(i32, 123)]
     struct Provider(#[import] TestModule2);
-    let provider = InitProvider.provide::<Provider>();
+    let provider: Provider = init!();
     // When
     let dep = provider.provide::<Box<i32>>();
     // Then
@@ -123,7 +121,7 @@ fn provide_with_module_with_ref_external_type_export_should_provide_its_members_
     #[injectable]
     #[provider]
     struct Provider(#[import] TestModule3);
-    let provider = InitProvider.provide::<Provider>();
+    let provider: Provider = init!();
     // When
     let dep = provider.provide::<&i32>();
     // Then
@@ -148,7 +146,7 @@ fn provide_with_module_with_factory_internal_export_should_provide_its_members_c
     #[injectable]
     #[provider]
     struct Provider(#[import] Module);
-    let provider = InitProvider.provide::<Provider>();
+    let provider: Provider = init!();
     // When
     let dep = provider.provide::<Ref<i32>>();
     let dep_ref = provider.provide::<&Ref<i32>>();

--- a/nject/tests/module_nested.rs
+++ b/nject/tests/module_nested.rs
@@ -1,7 +1,4 @@
-use nject::provider;
-
-#[provider]
-struct InitProvider;
+use nject::init;
 
 mod modules {
     use nject::{injectable, module};
@@ -97,35 +94,35 @@ mod same_scope {
 
 #[test]
 fn nested_provider_can_import_via_crate_path() {
-    let provider = InitProvider.provide::<providers::CrateProvider>();
+    let provider: providers::CrateProvider = init!();
     let facade = provider.provide::<providers::Facade>();
     assert_eq!(facade.0.0, 42);
 }
 
 #[test]
 fn nested_provider_can_import_deep_crate_path() {
-    let provider = InitProvider.provide::<providers::DeepProvider>();
+    let provider: providers::DeepProvider = init!();
     let facade = provider.provide::<providers::InnerFacade>();
     assert_eq!(facade.0.0, 7);
 }
 
 #[test]
 fn nested_provider_can_import_via_super_path() {
-    let provider = InitProvider.provide::<providers::inner::SuperProvider>();
+    let provider: providers::inner::SuperProvider = init!();
     let facade = provider.provide::<providers::Facade>();
     assert_eq!(facade.0.0, 42);
 }
 
 #[test]
 fn provider_can_import_module_in_same_scope_by_bare_name() {
-    let provider = InitProvider.provide::<same_scope::BareProvider>();
+    let provider: same_scope::BareProvider = init!();
     let facade = provider.provide::<same_scope::LocalFacade>();
     assert_eq!(facade.0.0, 99);
 }
 
 #[test]
 fn provider_can_import_module_in_same_scope_via_self_path() {
-    let provider = InitProvider.provide::<same_scope::SelfProvider>();
+    let provider: same_scope::SelfProvider = init!();
     let facade = provider.provide::<same_scope::LocalFacade>();
     assert_eq!(facade.0.0, 99);
 }

--- a/nject/tests/scope.rs
+++ b/nject/tests/scope.rs
@@ -1,4 +1,4 @@
-use nject::{inject, injectable, module, provider};
+use nject::{init, inject, injectable, module, provider};
 
 #[test]
 fn provide_with_type_providable_by_root_should_be_providable_by_scope() {
@@ -32,10 +32,7 @@ fn provide_with_type_providable_by_root_import_should_be_providable_by_scope() {
     #[derive(PartialEq, Debug)]
     struct ScopeDep<'a>(&'a i32);
 
-    #[provider]
-    struct InitProvider;
-
-    let root = InitProvider.provide::<Root>();
+    let root: Root = init!();
     let scope = root.scope();
     // When
     let scope_dep = scope.provide::<ScopeDep>();
@@ -112,10 +109,7 @@ fn provide_with_scoped_type_should_give_corresponding_value() {
     #[scope(ScopedDep)]
     struct Root(#[provide] RootDep);
 
-    #[provider]
-    struct InitProvider;
-
-    let root = InitProvider.provide::<Root>();
+    let root: Root = init!();
     let scope = root.scope();
     // When
     let value = scope.provide::<ScopedValue>();
@@ -143,10 +137,7 @@ fn provide_with_lifetime_on_scoped_type_should_give_corresponding_value() {
     #[scope(ScopedDep<'scope>)]
     struct Root(#[provide] RootDep);
 
-    #[provider]
-    struct InitProvider;
-
-    let root = InitProvider.provide::<Root>();
+    let root: Root = init!();
     let scope = root.scope();
     // When
     let value = scope.provide::<ScopedValue>();
@@ -245,23 +236,20 @@ fn scope_with_imported_module_iterable_should_iterate_exports() {
     #[module]
     #[export(&'prov dyn IntegerOwner, &self.0)]
     #[export(&'prov dyn IntegerOwner, &self.1)]
-    struct ScopeIterModule(
-        #[inject(Integer(1))] Integer,
-        #[inject(Integer(2))] Integer,
-    );
+    struct ScopeIterModule(#[inject(Integer(1))] Integer, #[inject(Integer(2))] Integer);
 
     #[injectable]
     #[provider]
     #[scope(#[import] ScopeIterModule)]
     struct Root;
 
-    #[provider]
-    struct InitProvider;
-
-    let root = InitProvider.provide::<Root>();
+    let root: Root = init!();
     let scope = root.scope();
     // When
-    let values: Vec<i32> = scope.iter::<&dyn IntegerOwner>().map(|o| o.value()).collect();
+    let values: Vec<i32> = scope
+        .iter::<&dyn IntegerOwner>()
+        .map(|o| o.value())
+        .collect();
     // Then
     assert_eq!(values, vec![1, 2]);
 }
@@ -284,13 +272,13 @@ fn scope_with_root_and_scope_modules_exporting_same_type_should_iterate_all() {
     #[scope(#[import] ScopeOnlyIterModule)]
     struct IterRoot(#[import] RootIterModule);
 
-    #[provider]
-    struct InitIterProvider;
-
-    let root = InitIterProvider.provide::<IterRoot>();
+    let root: IterRoot = init!();
     let scope = root.scope();
     // When
-    let values: Vec<i32> = scope.iter::<&dyn IntegerOwner>().map(|o| o.value()).collect();
+    let values: Vec<i32> = scope
+        .iter::<&dyn IntegerOwner>()
+        .map(|o| o.value())
+        .collect();
     // Then
     assert_eq!(values, vec![10, 20]);
 }


### PR DESCRIPTION
# Context
Injectable providers can be easily initialized using the `init!` macro.

## What
Allow `init!` to be initialized without modules.

## Why
Some providers are injectable even if they don't have modules.

## How
Remove the requirement to have at least one module when using the macro. 